### PR TITLE
docs: update docs to reflect mopidy's behavior on previous song

### DIFF
--- a/mopidy_mpd/protocol/playback.py
+++ b/mopidy_mpd/protocol/playback.py
@@ -235,34 +235,9 @@ def previous(context):
 
     *MPD's behaviour when affected by repeat/random/single/consume:*
 
-        Given a playlist of three tracks numbered 1, 2, 3, and a currently
-        playing track ``c``. ``previous_track`` is defined at the track
-        that will be played upon ``previous`` calls.
-
-        Tests performed on MPD 0.15.4-1ubuntu3.
-
-        ======  ======  ======  =======  =====  =====  =====
-                    Inputs                  previous_track
-        -------------------------------  -------------------
-        repeat  random  single  consume  c = 1  c = 2  c = 3
-        ======  ======  ======  =======  =====  =====  =====
-        T       T       T       T        Rand?  Rand?  Rand?
-        T       T       T       .        3      1      2
-        T       T       .       T        Rand?  Rand?  Rand?
-        T       T       .       .        3      1      2
-        T       .       T       T        3      1      2
-        T       .       T       .        3      1      2
-        T       .       .       T        3      1      2
-        T       .       .       .        3      1      2
-        .       T       T       T        c      c      c
-        .       T       T       .        c      c      c
-        .       T       .       T        c      c      c
-        .       T       .       .        c      c      c
-        .       .       T       T        1      1      2
-        .       .       T       .        1      1      2
-        .       .       .       T        1      1      2
-        .       .       .       .        1      1      2
-        ======  ======  ======  =======  =====  =====  =====
+    See the documentation for Mopidy core method
+    :meth:`TracklistController.get_previous_tlid`
+    for behavior when combining with one or more playback options.
 
         - If :attr:`time_position` of the current track is 15s or more,
           ``previous`` should do a seek to time position 0.


### PR DESCRIPTION
Fix the docs in regarding `previous` as requested in Mopidy's issue [#1694](https://github.com/mopidy/mopidy/issues/1694)