### PR TITLE
Filter list commands by title tag

### DIFF
--- a/mopidy_mpd/protocol/music_db.py
+++ b/mopidy_mpd/protocol/music_db.py
@@ -259,12 +259,12 @@ def list_(context, *args):
     """
     params = list(args)
     if not params:
-        raise exceptions.MpdArgError("incorrect arguments")
+        raise exceptions.MpdArgError('too few arguments for "list"')
 
-    field = params.pop(0).lower()
-    field = _LIST_MAPPING.get(field)
+    field_arg = params.pop(0).lower()
+    field = _LIST_MAPPING.get(field_arg)
     if field is None:
-        raise exceptions.MpdArgError("incorrect arguments")
+        raise exceptions.MpdArgError(f"Unknown tag type: {field_arg}")
 
     query = None
     if len(params) == 1:
@@ -276,9 +276,7 @@ def list_(context, *args):
         try:
             query = _query_from_mpd_search_parameters(params, _LIST_MAPPING)
         except exceptions.MpdArgError as exc:
-            exc.message = (  # noqa B306: Our own exception
-                "not able to parse args"
-            )
+            exc.message = "Unknown filter type"  # noqa B306: Our own exception
             raise
         except ValueError:
             return

--- a/mopidy_mpd/protocol/music_db.py
+++ b/mopidy_mpd/protocol/music_db.py
@@ -274,7 +274,7 @@ def list_(context, *args):
             query = {"artist": params}
     else:
         try:
-            query = _query_from_mpd_search_parameters(params, _LIST_MAPPING)
+            query = _query_from_mpd_search_parameters(params, _SEARCH_MAPPING)
         except exceptions.MpdArgError as exc:
             exc.message = "Unknown filter type"  # noqa B306: Our own exception
             raise

--- a/tests/protocol/test_music_db.py
+++ b/tests/protocol/test_music_db.py
@@ -747,6 +747,10 @@ class MusicDatabaseListTest(protocol.BaseTestCase):
         self.send_request('list "title"')
         self.assertInResponse("OK")
 
+    def test_list_title_by_title(self):
+        self.send_request('list "title" "title" "atitle"')
+        self.assertInResponse("OK")
+
     # Artist
 
     def test_list_artist_with_quotes(self):

--- a/tests/protocol/test_music_db.py
+++ b/tests/protocol/test_music_db.py
@@ -733,7 +733,13 @@ class MusicDatabaseListTest(protocol.BaseTestCase):
 
     def test_list_foo_returns_ack(self):
         self.send_request('list "foo"')
-        self.assertEqualResponse("ACK [2@0] {list} incorrect arguments")
+        self.assertEqualResponse("ACK [2@0] {list} Unknown tag type: foo")
+
+    def test_list_without_type_returns_ack(self):
+        self.send_request("list")
+        self.assertEqualResponse(
+            'ACK [2@0] {list} too few arguments for "list"'
+        )
 
     # Track title
 
@@ -763,7 +769,7 @@ class MusicDatabaseListTest(protocol.BaseTestCase):
 
     def test_list_artist_with_unknown_field_in_query_returns_ack(self):
         self.send_request('list "artist" "foo" "bar"')
-        self.assertEqualResponse("ACK [2@0] {list} not able to parse args")
+        self.assertEqualResponse("ACK [2@0] {list} Unknown filter type")
 
     def test_list_artist_by_artist(self):
         self.send_request('list "artist" "artist" "anartist"')
@@ -824,7 +830,7 @@ class MusicDatabaseListTest(protocol.BaseTestCase):
 
     def test_list_albumartist_with_unknown_field_in_query_returns_ack(self):
         self.send_request('list "albumartist" "foo" "bar"')
-        self.assertEqualResponse("ACK [2@0] {list} not able to parse args")
+        self.assertEqualResponse("ACK [2@0] {list} Unknown filter type")
 
     def test_list_albumartist_by_artist(self):
         self.send_request('list "albumartist" "artist" "anartist"')
@@ -890,7 +896,7 @@ class MusicDatabaseListTest(protocol.BaseTestCase):
 
     def test_list_composer_with_unknown_field_in_query_returns_ack(self):
         self.send_request('list "composer" "foo" "bar"')
-        self.assertEqualResponse("ACK [2@0] {list} not able to parse args")
+        self.assertEqualResponse("ACK [2@0] {list} Unknown filter type")
 
     def test_list_composer_by_artist(self):
         self.send_request('list "composer" "artist" "anartist"')
@@ -956,7 +962,7 @@ class MusicDatabaseListTest(protocol.BaseTestCase):
 
     def test_list_performer_with_unknown_field_in_query_returns_ack(self):
         self.send_request('list "performer" "foo" "bar"')
-        self.assertEqualResponse("ACK [2@0] {list} not able to parse args")
+        self.assertEqualResponse("ACK [2@0] {list} Unknown filter type")
 
     def test_list_performer_by_artist(self):
         self.send_request('list "performer" "artist" "anartist"')


### PR DESCRIPTION
A fix for #27 and some updated error messages while I am there.

A side effect of this change is that along with 'title', filtering by the following tags is now also possible:
* comment
* composer
* date
* file/filename
* track

Previously, specifying any of these would return an MPD ack error. 

Unfortunately, you still can't actually list by title or track (i.e. 'list title') like you should be able to. But that's something for another issue.