### PR TITLE
Skip browse results without a uri or name

### DIFF
--- a/mopidy_mpd/dispatcher.py
+++ b/mopidy_mpd/dispatcher.py
@@ -305,6 +305,9 @@ class MpdContext:
         while path_and_futures:
             base_path, future = path_and_futures.pop()
             for ref in future.get():
+                if ref.name is None or ref.uri is None:
+                    continue
+
                 path = "/".join([base_path, ref.name.replace("/", "")])
                 path = self._uri_map.insert(path, ref.uri)
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,10 +1,13 @@
 import unittest
 
 import pykka
+import pytest
 
 from mopidy import core
-from mopidy_mpd.dispatcher import MpdDispatcher
+from mopidy.models import Ref
+from mopidy_mpd.dispatcher import MpdContext, MpdDispatcher
 from mopidy_mpd.exceptions import MpdAckError
+from mopidy_mpd.uri_mapper import MpdUriMapper
 
 from tests import dummy_backend
 
@@ -39,3 +42,71 @@ class MpdDispatcherTest(unittest.TestCase):
             result[0]
             == 'ACK [0@0] {disabled} "disabled" has been disabled in the server'
         )
+
+
+@pytest.fixture
+def a_track():
+    return Ref.track(uri="dummy:/a", name="a")
+
+
+@pytest.fixture
+def b_track():
+    return Ref.track(uri="dummy:/foo/b", name="b")
+
+
+@pytest.fixture
+def backend_to_browse(a_track, b_track):
+    backend = dummy_backend.create_proxy()
+    backend.library.dummy_browse_result = {
+        "dummy:/": [a_track, Ref.directory(uri="dummy:/foo", name="foo")],
+        "dummy:/foo": [b_track],
+    }
+    return backend
+
+
+@pytest.fixture
+def mpd_context(backend_to_browse):
+    mopidy_core = core.Core.start(backends=[backend_to_browse]).proxy()
+    uri_map = MpdUriMapper(mopidy_core)
+    return MpdContext(None, core=mopidy_core, uri_map=uri_map)
+
+
+class TestMpdContext:
+    @classmethod
+    def teardown_class(cls):
+        pykka.ActorRegistry.stop_all()
+
+    def test_browse_root(self, mpd_context, a_track):
+        results = mpd_context.browse("dummy", recursive=False, lookup=False)
+
+        assert [("/dummy/a", a_track), ("/dummy/foo", None)] == list(results)
+
+    def test_browse_root_recursive(self, mpd_context, a_track, b_track):
+        results = mpd_context.browse("dummy", recursive=True, lookup=False)
+
+        assert [
+            ("/dummy", None),
+            ("/dummy/a", a_track),
+            ("/dummy/foo", None),
+            ("/dummy/foo/b", b_track),
+        ] == list(results)
+
+    @pytest.mark.parametrize(
+        "bad_ref",
+        [
+            Ref.track(uri="dummy:/x"),
+            Ref.track(name="x"),
+            Ref.directory(uri="dummy:/y"),
+            Ref.directory(name="y"),
+        ],
+    )
+    def test_browse_skips_bad_refs(
+        self, backend_to_browse, a_track, bad_ref, mpd_context
+    ):
+        backend_to_browse.library.dummy_browse_result = {
+            "dummy:/": [bad_ref, a_track],
+        }
+
+        results = mpd_context.browse("dummy", recursive=False, lookup=False)
+
+        assert [("/dummy/a", a_track)] == list(results)


### PR DESCRIPTION
#31 describes a an exception when dealing with a browse result that doesn't have name. It's not immediately obvious to me if we need to worry about any browse results that are missing either the `uri` or `name` and it seems easier to just skip them entirely.

I've also added a couple of super-simple tests for `MPDContext` since it didn't have any. And one that exposes the bug that's fixed in this PR. I did this pytest style but I can convert to unittest if we think that it's confusing to have both in the same file.