### PR TITLE
stub out 'tagtypes' subcommands

### DIFF
--- a/mopidy_mpd/protocol/reflection.py
+++ b/mopidy_mpd/protocol/reflection.py
@@ -82,14 +82,21 @@ def notcommands(context):
 
 
 @protocol.commands.add("tagtypes")
-def tagtypes(context):
+def tagtypes(context, *parameters):
     """
     *musicpd.org, reflection section:*
 
-        ``tagtypes``
+        ``tagtypes [ALL | CLEAR | DISABLE {NAME...] | ENABLE {NAME...]]``
 
         Shows a list of available song metadata.
     """
+    parameters = list(parameters)
+    if parameters:
+        subcommand = parameters.pop(0).lower()
+        if subcommand not in ("all", "clear", "disable", "enable"):
+            raise exceptions.MpdArgError("Unknown sub command")
+        # TODO: this is only a stub; we always return all tags anyhow.
+        return
     return [("tagtype", tagtype) for tagtype in tagtype_list.TAGTYPE_LIST]
 
 

--- a/tests/protocol/test_reflection.py
+++ b/tests/protocol/test_reflection.py
@@ -58,6 +58,26 @@ class ReflectionHandlerTest(protocol.BaseTestCase):
         self.assertInResponse("tagtype: MUSICBRAINZ_TRACKID")
         self.assertInResponse("OK")
 
+    def test_tagtypes_clear(self):
+        self.send_request("tagtypes clear")
+        self.assertInResponse("OK")
+
+    def test_tagtypes_all(self):
+        self.send_request("tagtypes all")
+        self.assertInResponse("OK")
+
+    def test_tagtypes_disable(self):
+        self.send_request("tagtypes disable x")
+        self.assertInResponse("OK")
+
+    def test_tagtypes_enable(self):
+        self.send_request("tagtypes enable x")
+        self.assertInResponse("OK")
+
+    def test_tagtypes_bogus(self):
+        self.send_request("tagtypes bogus")
+        self.assertEqualResponse("ACK [2@0] {tagtypes} Unknown sub command")
+
     def test_urlhandlers(self):
         self.send_request("urlhandlers")
         self.assertInResponse("OK")


### PR DESCRIPTION
fixes #48. This makes `mpc ls` work again.

This is related to #47 (our advertised MPD version being too old). 