### PR TITLE
Reject HTTP requests early

### DIFF
--- a/mopidy_mpd/network.py
+++ b/mopidy_mpd/network.py
@@ -454,6 +454,14 @@ class LineProtocol(pykka.ThreadingActor):
         self.connection.stop("Actor is shutting down.")
 
     def parse_lines(self):
+        """
+        All mpd commands begin with a lowercase letter
+        so we can immediately reject any potential HTTP request.
+        """
+        if self.recv_buffer[0] < ord('a') or self.recv_buffer[0] > ord('z'):
+            self.connection.stop("Invalid mpd command")
+            return
+
         """Consume new data and yield any lines found."""
         while re.search(self.terminator, self.recv_buffer):
             line, self.recv_buffer = self.delimiter.split(self.recv_buffer, 1)

--- a/mopidy_mpd/network.py
+++ b/mopidy_mpd/network.py
@@ -454,14 +454,6 @@ class LineProtocol(pykka.ThreadingActor):
         self.connection.stop("Actor is shutting down.")
 
     def parse_lines(self):
-        """
-        All mpd commands begin with a lowercase letter
-        so we can immediately reject any potential HTTP request.
-        """
-        if self.recv_buffer[0] < ord('a') or self.recv_buffer[0] > ord('z'):
-            self.connection.stop("Invalid mpd command")
-            return
-
         """Consume new data and yield any lines found."""
         while re.search(self.terminator, self.recv_buffer):
             line, self.recv_buffer = self.delimiter.split(self.recv_buffer, 1)

--- a/mopidy_mpd/session.py
+++ b/mopidy_mpd/session.py
@@ -31,7 +31,7 @@ class MpdSession(network.LineProtocol):
 
         # All mpd commands start with a lowercase alphabetic character
         # To prevent CSRF attacks, requests starting with an invalid character are immediately dropped.
-        if not (line[0].islower() and line[0].isalpha()):
+        if len(line) == 0 or not (line[0].islower() and line[0].isalpha()):
             self.connection.stop("Malformed command")
             return
 

--- a/mopidy_mpd/session.py
+++ b/mopidy_mpd/session.py
@@ -29,13 +29,14 @@ class MpdSession(network.LineProtocol):
     def on_line_received(self, line):
         logger.debug("Request from %s: %s", self.connection, line)
 
-        # To prevent CSRF attacks, lines with an invalid command syntax are immediately dropped.
-        command = line.split(" ")[0]
-        if not all(c.islower() and c.isalpha() or c == '_' for c in list(command)):
-            logger.debug("Dropping connection due to malformed command")
-            self.send_lines([f"ERR malformed command {command}"])
-            self.connection.stop("Malformed command")
-            return
+        # To prevent CSRF attacks, requests with an invalid command syntax are immediately dropped.
+        if len(line.split()) > 0:
+            command = line.split()[0]
+            if not all(c.islower() and c.isalpha() or c == '_' for c in list(command)):
+                logger.debug("Dropping connection due to malformed command")
+                self.send_lines([f"ERR malformed command {command}"])
+                self.connection.stop("Malformed command")
+                return
 
         response = self.dispatcher.handle_request(line)
         if not response:

--- a/tests/protocol/test_connection.py
+++ b/tests/protocol/test_connection.py
@@ -12,10 +12,10 @@ class ConnectionHandlerTest(protocol.BaseTestCase):
 
     def test_empty_request(self):
         self.send_request("")
-        self.assertEqualResponse("ACK [5@0] {} No command given")
+        self.assertNoResponse()
 
         self.send_request("  ")
-        self.assertEqualResponse("ACK [5@0] {} No command given")
+        self.assertNoResponse()
 
     def test_kill(self):
         self.send_request("kill")

--- a/tests/protocol/test_connection.py
+++ b/tests/protocol/test_connection.py
@@ -29,4 +29,4 @@ class ConnectionHandlerTest(protocol.BaseTestCase):
 
     def test_malformed_comamnd(self):
         self.send_request("GET / HTTP/1.1")
-        self.assertEqualResponse("ERR malformed command GET")
+        self.assertNoResponse()

--- a/tests/protocol/test_connection.py
+++ b/tests/protocol/test_connection.py
@@ -26,3 +26,7 @@ class ConnectionHandlerTest(protocol.BaseTestCase):
     def test_ping(self):
         self.send_request("ping")
         self.assertEqualResponse("OK")
+
+    def test_malformed_comamnd(self):
+        self.send_request("GET / HTTP/1.1")
+        self.assertEqualResponse("ERR malformed command GET")


### PR DESCRIPTION
As a safety measure to prevent CSRF attacks.
See:
https://github.com/mopidy/mopidy-mpd/issues/18
https://github.com/mopidy/mopidy/issues/1659