### PR TITLE
Remove any control characters in response

### DIFF
--- a/mopidy_mpd/network.py
+++ b/mopidy_mpd/network.py
@@ -12,6 +12,8 @@ from gi.repository import GLib
 logger = logging.getLogger(__name__)
 
 
+CONTROL_CHARS =  dict.fromkeys(range(32))
+
 def get_unix_socket_path(socket_path):
     match = re.search("^unix:(.*)", socket_path)
     if not match:
@@ -507,9 +509,8 @@ class LineProtocol(pykka.ThreadingActor):
         if not lines:
             return
 
-        # using translate() and fromkeys() to remove all control characters
-        mapping =  dict.fromkeys(range(32))
-        lines = list(map(lambda line: line.translate(mapping), lines))
+        # Remove all control characters (first 32 ascii characters)
+        lines = [l.translate(CONTROL_CHARS) for l in lines]
 
         data = self.join_lines(lines)
         self.connection.queue_send(self.encode(data))

--- a/mopidy_mpd/network.py
+++ b/mopidy_mpd/network.py
@@ -12,7 +12,7 @@ from gi.repository import GLib
 logger = logging.getLogger(__name__)
 
 
-CONTROL_CHARS =  dict.fromkeys(range(32))
+CONTROL_CHARS = dict.fromkeys(range(32))
 
 def get_unix_socket_path(socket_path):
     match = re.search("^unix:(.*)", socket_path)

--- a/mopidy_mpd/network.py
+++ b/mopidy_mpd/network.py
@@ -507,5 +507,9 @@ class LineProtocol(pykka.ThreadingActor):
         if not lines:
             return
 
+        # using translate() and fromkeys() to remove all control characters
+        mapping =  dict.fromkeys(range(32))
+        lines = list(map(lambda line: line.translate(mapping), lines))
+
         data = self.join_lines(lines)
         self.connection.queue_send(self.encode(data))

--- a/mopidy_mpd/network.py
+++ b/mopidy_mpd/network.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 CONTROL_CHARS = dict.fromkeys(range(32))
 
+
 def get_unix_socket_path(socket_path):
     match = re.search("^unix:(.*)", socket_path)
     if not match:

--- a/mopidy_mpd/network.py
+++ b/mopidy_mpd/network.py
@@ -510,7 +510,7 @@ class LineProtocol(pykka.ThreadingActor):
         if not lines:
             return
 
-        # Remove all control characters (first 32 ascii characters)
+        # Remove all control characters (first 32 ASCII characters)
         lines = [l.translate(CONTROL_CHARS) for l in lines]
 
         data = self.join_lines(lines)

--- a/tests/network/test_lineprotocol.py
+++ b/tests/network/test_lineprotocol.py
@@ -211,14 +211,14 @@ class LineProtocolTest(unittest.TestCase):
         self.mock.connection = Mock(spec=network.Connection)
         self.mock.join_lines.return_value = "lines"
 
-        network.LineProtocol.send_lines(self.mock, sentinel.lines)
-        self.mock.join_lines.assert_called_once_with(sentinel.lines)
+        network.LineProtocol.send_lines(self.mock, ["line 1", "line 2"])
+        self.mock.join_lines.assert_called_once_with(["line 1", "line 2"])
 
     def test_send_line_encodes_joined_lines_with_final_terminator(self):
         self.mock.connection = Mock(spec=network.Connection)
         self.mock.join_lines.return_value = "lines\n"
 
-        network.LineProtocol.send_lines(self.mock, sentinel.lines)
+        network.LineProtocol.send_lines(self.mock, ["line 1", "line 2"])
         self.mock.encode.assert_called_once_with("lines\n")
 
     def test_send_lines_sends_encoded_string(self):
@@ -226,7 +226,7 @@ class LineProtocolTest(unittest.TestCase):
         self.mock.join_lines.return_value = "lines"
         self.mock.encode.return_value = sentinel.data
 
-        network.LineProtocol.send_lines(self.mock, sentinel.lines)
+        network.LineProtocol.send_lines(self.mock, ["line 1", "line 2"])
         self.mock.connection.queue_send.assert_called_once_with(sentinel.data)
 
     def test_join_lines_returns_empty_string_for_no_lines(self):


### PR DESCRIPTION
I think this should fix https://github.com/mopidy/mopidy-mpd/issues/43 and https://github.com/mopidy/mopidy-mpd/issues/7.

I couldn't find a good method to escape the control characters while retaining all other special utf-8 characters, but escaping is more prone to errors anyway as different programs interpret escape sequences differently.

The characters are removed from the lines just before being joined, encoded and send.

Currently 3 tests are failing, which seems to be caused by a mock variable not behaving the same as it's real counterpart. I am not that experienced with unittest.mock so some advice there is welcome.

I also still have to write an appropriate unit test.