### PR TITLE
Make Unix sockets writable for user group

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,12 +91,21 @@ The following configuration values are available:
   - ``unix:/var/run/mopidy/mpd.sock``: Listen on the Unix socket at the
     specified path. Must be prefixed with ``unix:``.
     If `Mopidy is run as a system service <https://docs.mopidy.com/en/latest/running/service/>`_,
-    users must be added to the ``mopidy`` group (``usermod -a -G mopidy user``)
+    ``mpd/socket_permissions`` must allow group write access (default)
+    and users must be added to the ``mopidy`` group (``usermod -a -G mopidy user``)
     to communicate with the MPD server over a Unix socket.
 
 - ``mpd/port``:
   Which TCP port the MPD server should listen to.
   Default: 6600.
+
+- ``mpd/socket_permissions``:
+  The octal permission value used for the Unix socket created by the MPD server
+  (only applies if ``mpd/hostname`` is a unix socket).
+
+  - ``775``: rwx for user and group, r-x for others (default).
+  - ``777``: rwx for all users.
+  - ``755``: rwx for user, r-x for others.
 
 - ``mpd/password``:
   The password required for connecting to the MPD server.

--- a/README.rst
+++ b/README.rst
@@ -88,8 +88,10 @@ The following configuration values are available:
   - ``::1``: Listens only on the IPv6 loopback interface.
   - ``0.0.0.0``: Listens on all IPv4 interfaces.
   - ``::``: Listens on all interfaces, both IPv4 and IPv6.
-  - ``unix:/path/to/unix/socket.sock``: Listen on the Unix socket at the
+  - ``unix:/var/run/mopidy/mpd.sock``: Listen on the Unix socket at the
     specified path. Must be prefixed with ``unix:``.
+    Users must be added to the `mopidy` group (`usermod -a -G mopidy user`)
+    to communicate with MPD over a Unix socket.
 
 - ``mpd/port``:
   Which TCP port the MPD server should listen to.

--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ The following configuration values are available:
 
 - ``mpd/hostname``:
   Which address the MPD server should bind to.
-  This can be a network address or the path toa Unix socket:
+  This can be a network address or the path to a Unix socket:
 
   - ``127.0.0.1``: Listens only on the IPv4 loopback interface (default).
   - ``::1``: Listens only on the IPv6 loopback interface.
@@ -90,8 +90,9 @@ The following configuration values are available:
   - ``::``: Listens on all interfaces, both IPv4 and IPv6.
   - ``unix:/var/run/mopidy/mpd.sock``: Listen on the Unix socket at the
     specified path. Must be prefixed with ``unix:``.
-    Users must be added to the ``mopidy`` group (``usermod -a -G mopidy user``)
-    to communicate with MPD over a Unix socket.
+    If `Mopidy is run as a system service <https://docs.mopidy.com/en/latest/running/service/>`_,
+    users must be added to the ``mopidy`` group (``usermod -a -G mopidy user``)
+    to communicate with the MPD server over a Unix socket.
 
 - ``mpd/port``:
   Which TCP port the MPD server should listen to.

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ The following configuration values are available:
   - ``::``: Listens on all interfaces, both IPv4 and IPv6.
   - ``unix:/var/run/mopidy/mpd.sock``: Listen on the Unix socket at the
     specified path. Must be prefixed with ``unix:``.
-    Users must be added to the `mopidy` group (`usermod -a -G mopidy user`)
+    Users must be added to the ``mopidy`` group (``usermod -a -G mopidy user``)
     to communicate with MPD over a Unix socket.
 
 - ``mpd/port``:

--- a/mopidy_mpd/__init__.py
+++ b/mopidy_mpd/__init__.py
@@ -20,7 +20,7 @@ class Extension(ext.Extension):
         schema = super().get_config_schema()
         schema["hostname"] = config.Hostname()
         schema["port"] = config.Port(optional=True)
-        schema["socket_permissions"] = config.String()
+        schema["socket_permissions"] = config.String(optional=True)
         schema["password"] = config.Secret(optional=True)
         schema["max_connections"] = config.Integer(minimum=1)
         schema["connection_timeout"] = config.Integer(minimum=1)

--- a/mopidy_mpd/__init__.py
+++ b/mopidy_mpd/__init__.py
@@ -20,6 +20,7 @@ class Extension(ext.Extension):
         schema = super().get_config_schema()
         schema["hostname"] = config.Hostname()
         schema["port"] = config.Port(optional=True)
+        schema["socket_permissions"] = config.String()
         schema["password"] = config.Secret(optional=True)
         schema["max_connections"] = config.Integer(minimum=1)
         schema["connection_timeout"] = config.Integer(minimum=1)

--- a/mopidy_mpd/actor.py
+++ b/mopidy_mpd/actor.py
@@ -32,6 +32,7 @@ class MpdFrontend(pykka.ThreadingActor, CoreListener):
 
         self.hostname = network.format_hostname(config["mpd"]["hostname"])
         self.port = config["mpd"]["port"]
+        self.socket_permissions = config["mpd"]["socket_permissions"]
         self.uri_map = uri_mapper.MpdUriMapper(core)
 
         self.zeroconf_name = config["mpd"]["zeroconf"]
@@ -44,6 +45,7 @@ class MpdFrontend(pykka.ThreadingActor, CoreListener):
             server = network.Server(
                 self.hostname,
                 self.port,
+                self.socket_permissions,
                 protocol=session.MpdSession,
                 protocol_kwargs={
                     "config": config,

--- a/mopidy_mpd/actor.py
+++ b/mopidy_mpd/actor.py
@@ -45,7 +45,6 @@ class MpdFrontend(pykka.ThreadingActor, CoreListener):
             server = network.Server(
                 self.hostname,
                 self.port,
-                self.socket_permissions,
                 protocol=session.MpdSession,
                 protocol_kwargs={
                     "config": config,
@@ -54,6 +53,7 @@ class MpdFrontend(pykka.ThreadingActor, CoreListener):
                 },
                 max_connections=config["mpd"]["max_connections"],
                 timeout=config["mpd"]["connection_timeout"],
+                socket_permissions=self.socket_permissions,
             )
         except OSError as exc:
             raise exceptions.FrontendError(f"MPD server startup failed: {exc}")

--- a/mopidy_mpd/ext.conf
+++ b/mopidy_mpd/ext.conf
@@ -2,6 +2,7 @@
 enabled = true
 hostname = 127.0.0.1
 port = 6600
+socket_permissions = 775
 password =
 max_connections = 20
 connection_timeout = 60

--- a/mopidy_mpd/network.py
+++ b/mopidy_mpd/network.py
@@ -125,9 +125,12 @@ class Server:
         socket_path = get_unix_socket_path(host)
         if socket_path is not None:  # host is a path so use unix socket
             sock = create_unix_socket()
-            oldmask = os.umask(0o002) # make socket writable for users in the 'mopidy' group
-            sock.bind(socket_path)
-            os.umask(oldmask)
+            # make socket writable for users in the 'mopidy' group 
+            oldmask = os.umask(0o002)
+            try:
+                sock.bind(socket_path)
+            finally:
+                os.umask(oldmask)
         else:
             # ensure the port is supplied
             if not isinstance(port, int):

--- a/mopidy_mpd/network.py
+++ b/mopidy_mpd/network.py
@@ -125,7 +125,9 @@ class Server:
         socket_path = get_unix_socket_path(host)
         if socket_path is not None:  # host is a path so use unix socket
             sock = create_unix_socket()
+            oldmask = os.umask(0o002) # make socket writable for users in the 'mopidy' group
             sock.bind(socket_path)
+            os.umask(oldmask)
         else:
             # ensure the port is supplied
             if not isinstance(port, int):

--- a/tests/network/test_server.py
+++ b/tests/network/test_server.py
@@ -21,7 +21,7 @@ class ServerTest(unittest.TestCase):
             self.mock, sentinel.host, sentinel.port, sentinel.protocol
         )
         self.mock.create_server_socket.assert_called_once_with(
-            sentinel.host, sentinel.port
+            sentinel.host, sentinel.port, None
         )
         self.mock.stop()
 

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -31,6 +31,7 @@ def test_idle_hooked_up_correctly(event, expected):
         "mpd": {
             "hostname": "foobar",
             "port": 1234,
+            "socket_permissions": "775",
             "zeroconf": None,
             "max_connections": None,
             "connection_timeout": None,


### PR DESCRIPTION
When Mopidy is run as a system service under the `mopidy` user, Unix sockets are currently created with a umask of `022`, which makes other users unable to connect due to having no write permission. This PR ensures Unix sockets are created with a umask of `002`, making them writable to users in the `mopidy` group and thus usable to users added to this group.