### PR TITLE
Fix/dummy audio mopidy 3.4.0

### DIFF
--- a/mopidy_mpd/__init__.py
+++ b/mopidy_mpd/__init__.py
@@ -8,7 +8,6 @@ __version__ = pkg_resources.get_distribution("Mopidy-MPD").version
 
 
 class Extension(ext.Extension):
-
     dist_name = "Mopidy-MPD"
     ext_name = "mpd"
     version = __version__

--- a/mopidy_mpd/network.py
+++ b/mopidy_mpd/network.py
@@ -46,7 +46,7 @@ def get_socket_address(host, port):
         return (host, port)
 
 
-class ShouldRetrySocketCall(Exception):
+class ShouldRetrySocketCallError(Exception):
 
     """Indicate that attempted socket call should be retried"""
 
@@ -170,7 +170,7 @@ class Server:
     def handle_connection(self, fd, flags):
         try:
             sock, addr = self.accept_connection()
-        except ShouldRetrySocketCall:
+        except ShouldRetrySocketCallError:
             return True
 
         if self.maximum_connections_exceeded():
@@ -187,7 +187,7 @@ class Server:
             return sock, addr
         except OSError as e:
             if e.errno in (errno.EAGAIN, errno.EINTR):
-                raise ShouldRetrySocketCall
+                raise ShouldRetrySocketCallError
             raise
 
     def maximum_connections_exceeded(self):

--- a/mopidy_mpd/protocol/current_playlist.py
+++ b/mopidy_mpd/protocol/current_playlist.py
@@ -93,7 +93,7 @@ def delete(context, songrange):
     tl_tracks = context.core.tracklist.slice(start, end).get()
     if not tl_tracks:
         raise exceptions.MpdArgError("Bad song index", command="delete")
-    for (tlid, _) in tl_tracks:
+    for tlid, _ in tl_tracks:
         context.core.tracklist.remove({"tlid": [tlid]})
 
 
@@ -325,7 +325,7 @@ def plchangesposid(context, version):
     # XXX Naive implementation that returns all tracks as changed
     if int(version) != context.core.tracklist.get_version().get():
         result = []
-        for (position, (tlid, _)) in enumerate(
+        for position, (tlid, _) in enumerate(
             context.core.tracklist.get_tl_tracks().get()
         ):
             result.append(("cpos", position))

--- a/tests/dummy_audio.py
+++ b/tests/dummy_audio.py
@@ -21,7 +21,8 @@ class DummyAudio(pykka.ThreadingActor):
         self.state = audio.PlaybackState.STOPPED
         self._volume = 0
         self._position = 0
-        self._callback = None
+        self._source_setup_callback = None
+        self._about_to_finish_callback = None
         self._uri = None
         self._stream_changed = False
         self._live_stream = False
@@ -58,6 +59,7 @@ class DummyAudio(pykka.ThreadingActor):
 
     def prepare_change(self):
         self._uri = None
+        self._source_setup_callback = None
         return True
 
     def stop_playback(self):
@@ -76,8 +78,11 @@ class DummyAudio(pykka.ThreadingActor):
     def get_current_tags(self):
         return self._tags
 
+    def set_source_setup_callback(self, callback):
+        self._source_setup_callback = callback
+
     def set_about_to_finish_callback(self, callback):
-        self._callback = callback
+        self._about_to_finish_callback = callback
 
     def enable_sync_handler(self):
         pass
@@ -93,12 +98,12 @@ class DummyAudio(pykka.ThreadingActor):
             self._stream_changed = True
             self._uri = None
 
-        if self._uri is not None:
-            audio.AudioListener.send("position_changed", position=0)
-
         if self._stream_changed:
             self._stream_changed = False
             audio.AudioListener.send("stream_changed", uri=self._uri)
+
+        if self._uri is not None:
+            audio.AudioListener.send("position_changed", position=0)
 
         old_state, self.state = self.state, new_state
         audio.AudioListener.send(
@@ -121,14 +126,22 @@ class DummyAudio(pykka.ThreadingActor):
         self._tags.update(tags)
         audio.AudioListener.send("tags_changed", tags=self._tags.keys())
 
+    def get_source_setup_callback(self):
+        # This needs to be called from outside the actor or we lock up.
+        def wrapper():
+            if self._source_setup_callback:
+                self._source_setup_callback()
+
+        return wrapper
+
     def get_about_to_finish_callback(self):
         # This needs to be called from outside the actor or we lock up.
         def wrapper():
-            if self._callback:
+            if self._about_to_finish_callback:
                 self.prepare_change()
-                self._callback()
+                self._about_to_finish_callback()
 
-            if not self._uri or not self._callback:
+            if not self._uri or not self._about_to_finish_callback:
                 self._tags = {}
                 audio.AudioListener.send("reached_end_of_stream")
             else:

--- a/tests/network/test_server.py
+++ b/tests/network/test_server.py
@@ -250,7 +250,7 @@ class ServerTest(unittest.TestCase):
 
         for error in (errno.EAGAIN, errno.EINTR):
             sock.accept.side_effect = socket.error(error, "")
-            with self.assertRaises(network.ShouldRetrySocketCall):
+            with self.assertRaises(network.ShouldRetrySocketCallError):
                 network.Server.accept_connection(self.mock)
 
     # FIXME decide if this should be allowed to propegate

--- a/tests/protocol/test_regression.py
+++ b/tests/protocol/test_regression.py
@@ -169,7 +169,6 @@ class IssueGH69RegressionTest(protocol.BaseTestCase):
 
 
 class IssueGH113RegressionTest(protocol.BaseTestCase):
-
     r"""
     The issue: https://github.com/mopidy/mopidy/issues/113
 


### PR DESCRIPTION
Same as in https://github.com/mopidy/mopidy-local/pull/69

> The tests fail now when run against Mopidy 3.4.0 because the dummy audio actor here has not been updated for it
> 
> I just copied it from the Mopidy repo since that seems to be what has always been done in the past with this file, but let me know if there is a more preferred way to handle this
