### PR TITLE
Add type hints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
             python: "3.12"
             tox: py312
             coverage: true
+          - name: "Lint: pyright"
+            python: "3.12"
+            tox: pyright
           - name: "Lint: ruff lint"
             python: "3.12"
             tox: ruff-lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,12 @@ classifiers = [
 	"Programming Language :: Python :: 3.12",
 	"Topic :: Multimedia :: Sound/Audio :: Players",
 ]
-dependencies = ["mopidy >= 4.0.0a1", "pykka >= 4.0", "setuptools >= 66"]
+dependencies = [
+	"mopidy >= 4.0.0a1",
+	"pygobject >= 3.42",
+	"pykka >= 4.0",
+	"setuptools >= 66",
+]
 
 [project.optional-dependencies]
 lint = ["ruff"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,9 @@ select = [
 	"W",   # pycodestyle
 ]
 ignore = [
-	"ANN",    # flake8-annotations
+	"ANN101", # missing-type-self
+	"ANN102", # missing-type-cls
+	"ANN401", # any-type
 	"D",      # pydocstyle
 	"ISC001", # single-line-implicit-string-concatenation
 	"TRY003", # raise-vanilla-args

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 [project.optional-dependencies]
 lint = ["ruff"]
 test = ["pytest", "pytest-cov"]
-typing = ["pyright"]
+typing = ["pygobject-stubs", "pyright"]
 dev = ["mopidy-mpd[lint,test,typing]", "tox"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,16 @@ Issues = "https://github.com/mopidy/mopidy-mpd/issues"
 mpd = "mopidy_mpd:Extension"
 
 
+[tool.pyright]
+pythonVersion = "3.11"
+# Use venv from parent directory, to share it with any extensions:
+venvPath = "../"
+venv = ".venv"
+typeCheckingMode = "basic"
+# Already covered by flake8-self:
+reportPrivateImportUsage = false
+
+
 [tool.ruff]
 target-version = "py311"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ pythonVersion = "3.11"
 # Use venv from parent directory, to share it with any extensions:
 venvPath = "../"
 venv = ".venv"
-typeCheckingMode = "basic"
+typeCheckingMode = "standard"
 # Already covered by flake8-self:
 reportPrivateImportUsage = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 	"Programming Language :: Python :: 3.12",
 	"Topic :: Multimedia :: Sound/Audio :: Players",
 ]
-dependencies = ["mopidy >= 3.3.0", "pykka >= 4.0", "setuptools >= 66"]
+dependencies = ["mopidy >= 4.0.0a1", "pykka >= 4.0", "setuptools >= 66"]
 
 [project.optional-dependencies]
 lint = ["ruff"]

--- a/src/mopidy_mpd/__init__.py
+++ b/src/mopidy_mpd/__init__.py
@@ -11,10 +11,10 @@ class Extension(ext.Extension):
     ext_name = "mpd"
     version = __version__
 
-    def get_default_config(self):
+    def get_default_config(self) -> str:
         return config.read(pathlib.Path(__file__).parent / "ext.conf")
 
-    def get_config_schema(self):
+    def get_config_schema(self) -> config.ConfigSchema:
         schema = super().get_config_schema()
         schema["hostname"] = config.Hostname()
         schema["port"] = config.Port(optional=True)
@@ -26,7 +26,7 @@ class Extension(ext.Extension):
         schema["default_playlist_scheme"] = config.String()
         return schema
 
-    def setup(self, registry):
+    def setup(self, registry: ext.Registry) -> None:
         from .actor import MpdFrontend
 
         registry.add("frontend", MpdFrontend)

--- a/src/mopidy_mpd/actor.py
+++ b/src/mopidy_mpd/actor.py
@@ -33,14 +33,12 @@ class MpdFrontend(pykka.ThreadingActor, CoreListener):
         super().__init__()
 
         mpd_config = cast(types.MpdConfig, config.get("mpd", {}))
-
         self.hostname = network.format_hostname(mpd_config["hostname"])
         self.port = mpd_config["port"]
-        self.uri_map = uri_mapper.MpdUriMapper(core)
-
         self.zeroconf_name = mpd_config["zeroconf"]
         self.zeroconf_service = None
 
+        self.uri_map = uri_mapper.MpdUriMapper(core)
         self.server = self._setup_server(config, core)
 
     def _setup_server(self, config: Config, core: CoreProxy) -> network.Server:
@@ -48,14 +46,12 @@ class MpdFrontend(pykka.ThreadingActor, CoreListener):
 
         try:
             server = network.Server(
-                self.hostname,
-                self.port,
+                config=config,
+                core=core,
+                uri_map=self.uri_map,
                 protocol=session.MpdSession,
-                protocol_kwargs={
-                    "config": config,
-                    "core": core,
-                    "uri_map": self.uri_map,
-                },
+                host=self.hostname,
+                port=self.port,
                 max_connections=mpd_config["max_connections"],
                 timeout=mpd_config["connection_timeout"],
             )

--- a/src/mopidy_mpd/context.py
+++ b/src/mopidy_mpd/context.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    cast,
+    overload,
+)
+
+from mopidy_mpd import exceptions, types
+from mopidy_mpd.uri_mapper import MpdUriMapper
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    import pykka
+    from mopidy.core import CoreProxy
+    from mopidy.ext import Config
+    from mopidy.models import Ref, Track
+    from mopidy.types import Uri
+
+    from mopidy_mpd.dispatcher import MpdDispatcher
+    from mopidy_mpd.session import MpdSession
+
+
+logger = logging.getLogger(__name__)
+
+
+class MpdContext:
+    """
+    This object is passed as the first argument to all MPD command handlers to
+    give the command handlers access to important parts of Mopidy.
+    """
+
+    #: The Mopidy core API.
+    core: CoreProxy
+
+    #: The current session instance.
+    session: MpdSession
+
+    #: The current dispatcher instance.
+    dispatcher: MpdDispatcher
+
+    #: The MPD password.
+    password: str | None = None
+
+    #: The active subsystems that have pending events.
+    events: set[str]
+
+    #: The subsystems that we want to be notified about in idle mode.
+    subscriptions: set[str]
+
+    _uri_map: MpdUriMapper
+
+    def __init__(
+        self,
+        config: Config,
+        core: CoreProxy,
+        session: MpdSession,
+        dispatcher: MpdDispatcher,
+    ) -> None:
+        self.core = core
+        self.session = session
+        self.dispatcher = dispatcher
+
+        if config is not None:
+            mpd_config = cast(types.MpdConfig, config["mpd"])
+            self.password = mpd_config["password"]
+        self.events = set()
+        self.subscriptions = set()
+        self._uri_map = MpdUriMapper(core)
+
+    def lookup_playlist_uri_from_name(self, name: str) -> Uri | None:
+        """
+        Helper function to retrieve a playlist from its unique MPD name.
+        """
+        return self._uri_map.playlist_uri_from_name(name)
+
+    def lookup_playlist_name_from_uri(self, uri: Uri) -> str | None:
+        """
+        Helper function to retrieve the unique MPD playlist name from its uri.
+        """
+        return self._uri_map.playlist_name_from_uri(uri)
+
+    @overload
+    def browse(
+        self, path: str | None, *, recursive: bool, lookup: Literal[True]
+    ) -> Generator[tuple[str, pykka.Future[dict[Uri, list[Track]]] | None], Any, None]:
+        ...
+
+    @overload
+    def browse(
+        self, path: str | None, *, recursive: bool, lookup: Literal[False]
+    ) -> Generator[tuple[str, Ref | None], Any, None]:
+        ...
+
+    def browse(  # noqa: C901, PLR0912
+        self,
+        path: str | None,
+        *,
+        recursive: bool = True,
+        lookup: bool = True,
+    ) -> Generator[Any, Any, None]:
+        """
+        Browse the contents of a given directory path.
+
+        Returns a sequence of two-tuples ``(path, data)``.
+
+        If ``recursive`` is true, it returns results for all entries in the
+        given path.
+
+        If ``lookup`` is true and the ``path`` is to a track, the returned
+        ``data`` is a future which will contain the results from looking up
+        the URI with :meth:`mopidy.core.LibraryController.lookup`. If
+        ``lookup`` is false and the ``path`` is to a track, the returned
+        ``data`` will be a :class:`mopidy.models.Ref` for the track.
+
+        For all entries that are not tracks, the returned ``data`` will be
+        :class:`None`.
+        """
+
+        path_parts: list[str] = re.findall(r"[^/]+", path or "")
+        root_path: str = "/".join(["", *path_parts])
+
+        uri = self._uri_map.uri_from_name(root_path)
+        if uri is None:
+            for part in path_parts:
+                for ref in self.core.library.browse(uri).get():
+                    if ref.type != ref.TRACK and ref.name == part:
+                        uri = ref.uri
+                        break
+                else:
+                    raise exceptions.MpdNoExistError("Not found")
+            root_path = self._uri_map.insert(root_path, uri)
+
+        if recursive:
+            yield (root_path, None)
+
+        path_and_futures = [(root_path, self.core.library.browse(uri))]
+        while path_and_futures:
+            base_path, future = path_and_futures.pop()
+            for ref in future.get():
+                if ref.name is None or ref.uri is None:
+                    continue
+
+                path = "/".join([base_path, ref.name.replace("/", "")])
+                path = self._uri_map.insert(path, ref.uri)
+
+                if ref.type == ref.TRACK:
+                    if lookup:
+                        # TODO: can we lookup all the refs at once now?
+                        yield (path, self.core.library.lookup(uris=[ref.uri]))
+                    else:
+                        yield (path, ref)
+                else:
+                    yield (path, None)
+                    if recursive:
+                        path_and_futures.append(
+                            (path, self.core.library.browse(ref.uri))
+                        )

--- a/src/mopidy_mpd/context.py
+++ b/src/mopidy_mpd/context.py
@@ -11,19 +11,19 @@ from typing import (
 )
 
 from mopidy_mpd import exceptions, types
-from mopidy_mpd.uri_mapper import MpdUriMapper
 
 if TYPE_CHECKING:
     from collections.abc import Generator
 
     import pykka
+    from mopidy.config import Config
     from mopidy.core import CoreProxy
-    from mopidy.ext import Config
     from mopidy.models import Ref, Track
     from mopidy.types import Uri
 
     from mopidy_mpd.dispatcher import MpdDispatcher
     from mopidy_mpd.session import MpdSession
+    from mopidy_mpd.uri_mapper import MpdUriMapper
 
 
 logger = logging.getLogger(__name__)
@@ -50,22 +50,22 @@ class MpdContext:
     #: Mapping of URIs to MPD names.
     uri_map: MpdUriMapper
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         config: Config,
         core: CoreProxy,
+        uri_map: MpdUriMapper,
         session: MpdSession,
         dispatcher: MpdDispatcher,
     ) -> None:
         self.core = core
+        self.uri_map = uri_map
         self.session = session
         self.dispatcher = dispatcher
 
         if config is not None:
-            mpd_config = cast(types.MpdConfig, config["mpd"])
+            mpd_config = cast(types.MpdConfig, config.get("mpd", {}))
             self.password = mpd_config["password"]
-
-        self.uri_map = MpdUriMapper(core)
 
     @overload
     def browse(

--- a/src/mopidy_mpd/context.py
+++ b/src/mopidy_mpd/context.py
@@ -47,12 +47,6 @@ class MpdContext:
     #: The MPD password.
     password: str | None = None
 
-    #: The active subsystems that have pending events.
-    events: set[str]
-
-    #: The subsystems that we want to be notified about in idle mode.
-    subscriptions: set[str]
-
     #: Mapping of URIs to MPD names.
     uri_map: MpdUriMapper
 
@@ -70,8 +64,7 @@ class MpdContext:
         if config is not None:
             mpd_config = cast(types.MpdConfig, config["mpd"])
             self.password = mpd_config["password"]
-        self.events = set()
-        self.subscriptions = set()
+
         self.uri_map = MpdUriMapper(core)
 
     @overload

--- a/src/mopidy_mpd/context.py
+++ b/src/mopidy_mpd/context.py
@@ -6,7 +6,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
-    cast,
     overload,
 )
 
@@ -16,7 +15,6 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
     import pykka
-    from mopidy.config import Config
     from mopidy.core import CoreProxy
     from mopidy.models import Ref, Track
     from mopidy.types import Uri
@@ -35,6 +33,9 @@ class MpdContext:
     give the command handlers access to important parts of Mopidy.
     """
 
+    #: The Mopidy config.
+    config: types.Config
+
     #: The Mopidy core API.
     core: CoreProxy
 
@@ -44,28 +45,22 @@ class MpdContext:
     #: The current dispatcher instance.
     dispatcher: MpdDispatcher
 
-    #: The MPD password.
-    password: str | None = None
-
     #: Mapping of URIs to MPD names.
     uri_map: MpdUriMapper
 
     def __init__(  # noqa: PLR0913
         self,
-        config: Config,
+        config: types.Config,
         core: CoreProxy,
         uri_map: MpdUriMapper,
         session: MpdSession,
         dispatcher: MpdDispatcher,
     ) -> None:
+        self.config = config
         self.core = core
         self.uri_map = uri_map
         self.session = session
         self.dispatcher = dispatcher
-
-        if config is not None:
-            mpd_config = cast(types.MpdConfig, config.get("mpd", {}))
-            self.password = mpd_config["password"]
 
     @overload
     def browse(

--- a/src/mopidy_mpd/dispatcher.py
+++ b/src/mopidy_mpd/dispatcher.py
@@ -106,7 +106,7 @@ class MpdDispatcher:
         self.session.send_lines(response)
 
     def _call_next_filter(
-        self, request: str, response: Response, filter_chain: list[Filter]
+        self, request: Request, response: Response, filter_chain: list[Filter]
     ) -> Response:
         if filter_chain:
             next_filter = filter_chain.pop(0)
@@ -175,10 +175,10 @@ class MpdDispatcher:
             response = Response(response[:-1])
         return response
 
-    def _is_receiving_command_list(self, request: str) -> bool:
+    def _is_receiving_command_list(self, request: Request) -> bool:
         return self.command_list_receiving and request != "command_list_end"
 
-    def _is_processing_command_list(self, request: str) -> bool:
+    def _is_processing_command_list(self, request: Request) -> bool:
         return self.command_list_index is not None and request != "command_list_end"
 
     # --- Filter: idle
@@ -243,7 +243,7 @@ class MpdDispatcher:
             logger.warning("Tried to communicate with dead actor.")
             raise exceptions.MpdSystemError(str(exc)) from exc
 
-    def _call_handler(self, request: str) -> protocol.Result:
+    def _call_handler(self, request: Request) -> protocol.Result:
         tokens = tokenize.split(request)
         # TODO: check that blacklist items are valid commands?
         blacklist = self.config["mpd"]["command_blacklist"]

--- a/src/mopidy_mpd/dispatcher.py
+++ b/src/mopidy_mpd/dispatcher.py
@@ -2,28 +2,22 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Callable, Generator
+from collections.abc import Callable
 from typing import (
     TYPE_CHECKING,
-    Any,
-    Literal,
     NewType,
     TypeAlias,
     TypeVar,
     cast,
-    overload,
 )
 
 import pykka
 
-from mopidy_mpd import exceptions, protocol, tokenize, types
-from mopidy_mpd.uri_mapper import MpdUriMapper
+from mopidy_mpd import context, exceptions, protocol, tokenize, types
 
 if TYPE_CHECKING:
     from mopidy.core import CoreProxy
     from mopidy.ext import Config
-    from mopidy.models import Ref, Track
-    from mopidy.types import Uri
 
     from mopidy_mpd.session import MpdSession
 
@@ -60,11 +54,11 @@ class MpdDispatcher:
         self.command_list_ok = False
         self.command_list = []
         self.command_list_index = None
-        self.context = MpdContext(
-            core=core,
-            dispatcher=self,
-            session=session,
+        self.context = context.MpdContext(
             config=config,
+            core=core,
+            session=session,
+            dispatcher=self,
         )
 
     def handle_request(
@@ -289,136 +283,3 @@ class MpdDispatcher:
             (key, value) = element
             return Response([f"{key}: {value}"])
         return Response([element])
-
-
-class MpdContext:
-    """
-    This object is passed as the first argument to all MPD command handlers to
-    give the command handlers access to important parts of Mopidy.
-    """
-
-    #: The Mopidy core API.
-    core: CoreProxy
-
-    #: The current dispatcher instance.
-    dispatcher: MpdDispatcher
-
-    #: The current session instance.
-    session: MpdSession
-
-    #: The MPD password.
-    password: str | None = None
-
-    #: The active subsystems that have pending events.
-    events: set[str]
-
-    #: The subsystems that we want to be notified about in idle mode.
-    subscriptions: set[str]
-
-    _uri_map: MpdUriMapper
-
-    def __init__(
-        self,
-        config: Config,
-        core: CoreProxy,
-        dispatcher: MpdDispatcher,
-        session: MpdSession,
-    ) -> None:
-        self.core = core
-        self.dispatcher = dispatcher
-        self.session = session
-        if config is not None:
-            mpd_config = cast(types.MpdConfig, config["mpd"])
-            self.password = mpd_config["password"]
-        self.events = set()
-        self.subscriptions = set()
-        self._uri_map = MpdUriMapper(core)
-
-    def lookup_playlist_uri_from_name(self, name: str) -> Uri | None:
-        """
-        Helper function to retrieve a playlist from its unique MPD name.
-        """
-        return self._uri_map.playlist_uri_from_name(name)
-
-    def lookup_playlist_name_from_uri(self, uri: Uri) -> str | None:
-        """
-        Helper function to retrieve the unique MPD playlist name from its uri.
-        """
-        return self._uri_map.playlist_name_from_uri(uri)
-
-    @overload
-    def browse(
-        self, path: str | None, *, recursive: bool, lookup: Literal[True]
-    ) -> Generator[tuple[str, pykka.Future[dict[Uri, list[Track]]] | None], Any, None]:
-        ...
-
-    @overload
-    def browse(
-        self, path: str | None, *, recursive: bool, lookup: Literal[False]
-    ) -> Generator[tuple[str, Ref | None], Any, None]:
-        ...
-
-    def browse(  # noqa: C901, PLR0912
-        self,
-        path: str | None,
-        *,
-        recursive: bool = True,
-        lookup: bool = True,
-    ) -> Generator[Any, Any, None]:
-        """
-        Browse the contents of a given directory path.
-
-        Returns a sequence of two-tuples ``(path, data)``.
-
-        If ``recursive`` is true, it returns results for all entries in the
-        given path.
-
-        If ``lookup`` is true and the ``path`` is to a track, the returned
-        ``data`` is a future which will contain the results from looking up
-        the URI with :meth:`mopidy.core.LibraryController.lookup`. If
-        ``lookup`` is false and the ``path`` is to a track, the returned
-        ``data`` will be a :class:`mopidy.models.Ref` for the track.
-
-        For all entries that are not tracks, the returned ``data`` will be
-        :class:`None`.
-        """
-
-        path_parts: list[str] = re.findall(r"[^/]+", path or "")
-        root_path: str = "/".join(["", *path_parts])
-
-        uri = self._uri_map.uri_from_name(root_path)
-        if uri is None:
-            for part in path_parts:
-                for ref in self.core.library.browse(uri).get():
-                    if ref.type != ref.TRACK and ref.name == part:
-                        uri = ref.uri
-                        break
-                else:
-                    raise exceptions.MpdNoExistError("Not found")
-            root_path = self._uri_map.insert(root_path, uri)
-
-        if recursive:
-            yield (root_path, None)
-
-        path_and_futures = [(root_path, self.core.library.browse(uri))]
-        while path_and_futures:
-            base_path, future = path_and_futures.pop()
-            for ref in future.get():
-                if ref.name is None or ref.uri is None:
-                    continue
-
-                path = "/".join([base_path, ref.name.replace("/", "")])
-                path = self._uri_map.insert(path, ref.uri)
-
-                if ref.type == ref.TRACK:
-                    if lookup:
-                        # TODO: can we lookup all the refs at once now?
-                        yield (path, self.core.library.lookup(uris=[ref.uri]))
-                    else:
-                        yield (path, ref)
-                else:
-                    yield (path, None)
-                    if recursive:
-                        path_and_futures.append(
-                            (path, self.core.library.browse(ref.uri))
-                        )

--- a/src/mopidy_mpd/dispatcher.py
+++ b/src/mopidy_mpd/dispatcher.py
@@ -15,10 +15,11 @@ import pykka
 from mopidy_mpd import context, exceptions, protocol, tokenize, types
 
 if TYPE_CHECKING:
+    from mopidy.config import Config
     from mopidy.core import CoreProxy
-    from mopidy.ext import Config
 
     from mopidy_mpd.session import MpdSession
+    from mopidy_mpd.uri_mapper import MpdUriMapper
 
 
 logger = logging.getLogger(__name__)
@@ -48,6 +49,7 @@ class MpdDispatcher:
         self,
         config: Config,
         core: CoreProxy,
+        uri_map: MpdUriMapper,
         session: MpdSession,
     ) -> None:
         self.config = config
@@ -67,6 +69,7 @@ class MpdDispatcher:
         self.context = context.MpdContext(
             config=config,
             core=core,
+            uri_map=uri_map,
             session=session,
             dispatcher=self,
         )

--- a/src/mopidy_mpd/dispatcher.py
+++ b/src/mopidy_mpd/dispatcher.py
@@ -55,6 +55,7 @@ class MpdDispatcher:
     ) -> None:
         self.config = config
         self.mpd_config = cast(types.MpdConfig, config.get("mpd", {}) if config else {})
+        self.session = session
 
         self.authenticated = False
 
@@ -105,7 +106,7 @@ class MpdDispatcher:
         response.append("OK")
         self.subsystem_events = set()
         self.subsystem_subscriptions = set()
-        self.context.session.send_lines(response)
+        self.session.send_lines(response)
 
     def _call_next_filter(
         self, request: str, response: Response, filter_chain: list[Filter]
@@ -197,7 +198,7 @@ class MpdDispatcher:
                 repr(request),
                 repr("noidle"),
             )
-            self.context.session.close()
+            self.session.close()
             return Response([])
 
         if not self._is_currently_idle() and self._noidle.match(request):

--- a/src/mopidy_mpd/dispatcher.py
+++ b/src/mopidy_mpd/dispatcher.py
@@ -1,41 +1,83 @@
+from __future__ import annotations
+
 import logging
 import re
+from collections.abc import Callable, Generator
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    NewType,
+    TypeAlias,
+    TypeVar,
+    cast,
+    overload,
+)
 
 import pykka
 
-from mopidy_mpd import exceptions, protocol, tokenize
+from mopidy_mpd import exceptions, protocol, tokenize, types
+
+if TYPE_CHECKING:
+    from mopidy.core import CoreProxy
+    from mopidy.ext import Config
+    from mopidy.models import Ref, Track
+    from mopidy.types import Uri
+
+    from mopidy_mpd.session import MpdSession
+    from mopidy_mpd.uri_mapper import MpdUriMapper
+
 
 logger = logging.getLogger(__name__)
 
 protocol.load_protocol_modules()
 
+T = TypeVar("T")
+Request: TypeAlias = str
+Response = NewType("Response", list[str])
+Filter: TypeAlias = Callable[[Request, Response, list["Filter"]], Response]
+
 
 class MpdDispatcher:
-
     """
     The MPD session feeds the MPD dispatcher with requests. The dispatcher
-    finds the correct handler, processes the request and sends the response
+    finds the correct handler, processes the request, and sends the response
     back to the MPD session.
     """
 
     _noidle = re.compile(r"^noidle$")
 
-    def __init__(self, session=None, config=None, core=None, uri_map=None):
+    def __init__(
+        self,
+        config: Config,
+        core: CoreProxy,
+        session: MpdSession,
+        uri_map: MpdUriMapper,
+    ) -> None:
         self.config = config
+        self.mpd_config = cast(types.MpdConfig, config.get("mpd", {}) if config else {})
         self.authenticated = False
         self.command_list_receiving = False
         self.command_list_ok = False
         self.command_list = []
         self.command_list_index = None
         self.context = MpdContext(
-            self, session=session, config=config, core=core, uri_map=uri_map
+            core=core,
+            dispatcher=self,
+            session=session,
+            config=config,
+            uri_map=uri_map,
         )
 
-    def handle_request(self, request, current_command_list_index=None):
+    def handle_request(
+        self,
+        request: Request,
+        current_command_list_index: int | None = None,
+    ) -> Response:
         """Dispatch incoming requests to the correct handler."""
         self.command_list_index = current_command_list_index
-        response = []
-        filter_chain = [
+        response: Response = []
+        filter_chain: list[Filter] = [
             self._catch_mpd_ack_errors_filter,
             self._authenticate_filter,
             self._command_list_filter,
@@ -45,7 +87,7 @@ class MpdDispatcher:
         ]
         return self._call_next_filter(request, response, filter_chain)
 
-    def handle_idle(self, subsystem):
+    def handle_idle(self, subsystem: str) -> None:
         # TODO: validate against mopidy_mpd/protocol/status.SUBSYSTEMS
         self.context.events.add(subsystem)
 
@@ -53,7 +95,7 @@ class MpdDispatcher:
         if not subsystems:
             return
 
-        response = []
+        response: list[str] = []
         for subsystem in subsystems:
             response.append(f"changed: {subsystem}")
         response.append("OK")
@@ -61,7 +103,9 @@ class MpdDispatcher:
         self.context.events = set()
         self.context.session.send_lines(response)
 
-    def _call_next_filter(self, request, response, filter_chain):
+    def _call_next_filter(
+        self, request: str, response: Response, filter_chain: list[Filter]
+    ) -> Response:
         if filter_chain:
             next_filter = filter_chain.pop(0)
             return next_filter(request, response, filter_chain)
@@ -69,17 +113,27 @@ class MpdDispatcher:
 
     # --- Filter: catch MPD ACK errors
 
-    def _catch_mpd_ack_errors_filter(self, request, response, filter_chain):
+    def _catch_mpd_ack_errors_filter(
+        self,
+        request: Request,
+        response: Response,
+        filter_chain: list[Filter],
+    ) -> Response:
         try:
             return self._call_next_filter(request, response, filter_chain)
         except exceptions.MpdAckError as mpd_ack_error:
             if self.command_list_index is not None:
                 mpd_ack_error.index = self.command_list_index
-            return [mpd_ack_error.get_mpd_ack()]
+            return Response([mpd_ack_error.get_mpd_ack()])
 
     # --- Filter: authenticate
 
-    def _authenticate_filter(self, request, response, filter_chain):
+    def _authenticate_filter(
+        self,
+        request: Request,
+        response: Response,
+        filter_chain: list[Filter],
+    ) -> Response:
         if self.authenticated:
             return self._call_next_filter(request, response, filter_chain)
 
@@ -97,7 +151,12 @@ class MpdDispatcher:
 
     # --- Filter: command list
 
-    def _command_list_filter(self, request, response, filter_chain):
+    def _command_list_filter(
+        self,
+        request: Request,
+        response: Response,
+        filter_chain: list[Filter],
+    ) -> Response:
         if self._is_receiving_command_list(request):
             self.command_list.append(request)
             return []
@@ -111,18 +170,23 @@ class MpdDispatcher:
             and response
             and response[-1] == "OK"
         ):
-            response = response[:-1]
+            response = Response(response[:-1])
         return response
 
-    def _is_receiving_command_list(self, request):
+    def _is_receiving_command_list(self, request: str) -> bool:
         return self.command_list_receiving and request != "command_list_end"
 
-    def _is_processing_command_list(self, request):
+    def _is_processing_command_list(self, request: str) -> bool:
         return self.command_list_index is not None and request != "command_list_end"
 
     # --- Filter: idle
 
-    def _idle_filter(self, request, response, filter_chain):
+    def _idle_filter(
+        self,
+        request: Request,
+        response: Response,
+        filter_chain: list[Filter],
+    ) -> Response:
         if self._is_currently_idle() and not self._noidle.match(request):
             logger.debug(
                 "Client sent us %s, only %s is allowed while in " "the idle state",
@@ -142,127 +206,168 @@ class MpdDispatcher:
 
         return response
 
-    def _is_currently_idle(self):
+    def _is_currently_idle(self) -> bool:
         return bool(self.context.subscriptions)
 
     # --- Filter: add OK
 
-    def _add_ok_filter(self, request, response, filter_chain):
+    def _add_ok_filter(
+        self,
+        request: Request,
+        response: Response,
+        filter_chain: list[Filter],
+    ) -> Response:
         response = self._call_next_filter(request, response, filter_chain)
         if not self._has_error(response):
             response.append("OK")
         return response
 
-    def _has_error(self, response):
-        return response and response[-1].startswith("ACK")
+    def _has_error(self, response: Response) -> bool:
+        return bool(response) and response[-1].startswith("ACK")
 
     # --- Filter: call handler
 
-    def _call_handler_filter(self, request, response, filter_chain):
+    def _call_handler_filter(
+        self,
+        request: Request,
+        response: Response,
+        filter_chain: list[Filter],
+    ) -> Response:
         try:
-            response = self._format_response(self._call_handler(request))
+            result = self._call_handler(request)
+            response = self._format_response(result)
             return self._call_next_filter(request, response, filter_chain)
         except pykka.ActorDeadError as exc:
             logger.warning("Tried to communicate with dead actor.")
-            raise exceptions.MpdSystemError(exc) from exc
+            raise exceptions.MpdSystemError(str(exc)) from exc
 
-    def _call_handler(self, request):
+    def _call_handler(self, request: str) -> protocol.Result:
         tokens = tokenize.split(request)
         # TODO: check that blacklist items are valid commands?
-        blacklist = self.config["mpd"].get("command_blacklist", [])
+        blacklist = self.mpd_config.get("command_blacklist", [])
         if tokens and tokens[0] in blacklist:
             logger.warning("MPD client used blacklisted command: %s", tokens[0])
             raise exceptions.MpdDisabledError(command=tokens[0])
         try:
-            return protocol.commands.call(tokens, context=self.context)
+            return protocol.commands.call(
+                context=self.context,
+                tokens=tokens,
+            )
         except exceptions.MpdAckError as exc:
             if exc.command is None:
                 exc.command = tokens[0]
             raise
 
-    def _format_response(self, response):
-        formatted_response = []
-        for element in self._listify_result(response):
-            formatted_response.extend(self._format_lines(element))
-        return formatted_response
+    def _format_response(self, result: protocol.Result) -> Response:
+        response = Response([])
+        for element in self._listify_result(result):
+            response.extend(self._format_lines(element))
+        return response
 
-    def _listify_result(self, result):
-        if result is None:
-            return []
-        if isinstance(result, set):
-            return self._flatten(list(result))
-        if not isinstance(result, list):
-            return [result]
-        return self._flatten(result)
+    def _listify_result(self, result: protocol.Result) -> protocol.ResultList:
+        match result:
+            case None:
+                return []
+            case list():
+                return self._flatten(result)
+            case _:
+                return [result]
 
-    def _flatten(self, the_list):
-        result = []
-        for element in the_list:
+    def _flatten(self, lst: protocol.ResultList) -> protocol.ResultList:
+        result: protocol.ResultList = []
+        for element in lst:
             if isinstance(element, list):
                 result.extend(self._flatten(element))
             else:
                 result.append(element)
         return result
 
-    def _format_lines(self, line):
-        if isinstance(line, dict):
-            return [f"{key}: {value}" for (key, value) in line.items()]
-        if isinstance(line, tuple):
-            (key, value) = line
-            return [f"{key}: {value}"]
-        return [line]
+    def _format_lines(
+        self, element: protocol.ResultDict | protocol.ResultTuple | str
+    ) -> Response:
+        if isinstance(element, dict):
+            return Response([f"{key}: {value}" for (key, value) in element.items()])
+        if isinstance(element, tuple):
+            (key, value) = element
+            return Response([f"{key}: {value}"])
+        return Response([element])
 
 
 class MpdContext:
-
     """
     This object is passed as the first argument to all MPD command handlers to
     give the command handlers access to important parts of Mopidy.
     """
 
-    #: The current :class:`MpdDispatcher`.
-    dispatcher = None
+    #: The Mopidy core API.
+    core: CoreProxy
 
-    #: The current :class:`mopidy_mpd.MpdSession`.
-    session = None
+    _uri_map: MpdUriMapper
 
-    #: The MPD password
-    password = None
+    #: The current dispatcher instance.
+    dispatcher: MpdDispatcher
 
-    #: The Mopidy core API. An instance of :class:`mopidy.core.Core`.
-    core = None
+    #: The current session instance.
+    session: MpdSession
+
+    #: The MPD password.
+    password: str | None = None
 
     #: The active subsystems that have pending events.
-    events = None
+    events: set[str]
 
-    #: The subsytems that we want to be notified about in idle mode.
-    subscriptions = None
+    #: The subsystems that we want to be notified about in idle mode.
+    subscriptions: set[str]
 
-    _uri_map = None
-
-    def __init__(self, dispatcher, session=None, config=None, core=None, uri_map=None):  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913
+        self,
+        config: Config,
+        core: CoreProxy,
+        uri_map: MpdUriMapper,
+        dispatcher: MpdDispatcher,
+        session: MpdSession,
+    ) -> None:
+        self.core = core
+        self._uri_map = uri_map
         self.dispatcher = dispatcher
         self.session = session
         if config is not None:
-            self.password = config["mpd"]["password"]
-        self.core = core
+            mpd_config = cast(types.MpdConfig, config["mpd"])
+            self.password = mpd_config["password"]
         self.events = set()
         self.subscriptions = set()
-        self._uri_map = uri_map
 
-    def lookup_playlist_uri_from_name(self, name):
+    def lookup_playlist_uri_from_name(self, name: str) -> Uri | None:
         """
         Helper function to retrieve a playlist from its unique MPD name.
         """
         return self._uri_map.playlist_uri_from_name(name)
 
-    def lookup_playlist_name_from_uri(self, uri):
+    def lookup_playlist_name_from_uri(self, uri: Uri) -> str | None:
         """
         Helper function to retrieve the unique MPD playlist name from its uri.
         """
         return self._uri_map.playlist_name_from_uri(uri)
 
-    def browse(self, path, *, recursive=True, lookup=True):  # noqa: C901, PLR0912
+    @overload
+    def browse(
+        self, path: str | None, *, recursive: bool, lookup: Literal[True]
+    ) -> Generator[tuple[str, pykka.Future[dict[Uri, list[Track]]] | None], Any, None]:
+        ...
+
+    @overload
+    def browse(
+        self, path: str | None, *, recursive: bool, lookup: Literal[False]
+    ) -> Generator[tuple[str, Ref | None], Any, None]:
+        ...
+
+    def browse(  # noqa: C901, PLR0912
+        self,
+        path: str | None,
+        *,
+        recursive: bool = True,
+        lookup: bool = True,
+    ) -> Generator[Any, Any, None]:
         """
         Browse the contents of a given directory path.
 
@@ -281,8 +386,8 @@ class MpdContext:
         :class:`None`.
         """
 
-        path_parts = re.findall(r"[^/]+", path or "")
-        root_path = "/".join(["", *path_parts])
+        path_parts: list[str] = re.findall(r"[^/]+", path or "")
+        root_path: str = "/".join(["", *path_parts])
 
         uri = self._uri_map.uri_from_name(root_path)
         if uri is None:

--- a/src/mopidy_mpd/dispatcher.py
+++ b/src/mopidy_mpd/dispatcher.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from collections.abc import Callable
 from typing import (
     TYPE_CHECKING,
@@ -38,8 +37,6 @@ class MpdDispatcher:
     finds the correct handler, processes the request, and sends the response
     back to the MPD session.
     """
-
-    _noidle = re.compile(r"^noidle$")
 
     #: The active subsystems that have pending events.
     subsystem_events: set[str]
@@ -192,16 +189,16 @@ class MpdDispatcher:
         response: Response,
         filter_chain: list[Filter],
     ) -> Response:
-        if self._is_currently_idle() and not self._noidle.match(request):
+        if self._is_currently_idle() and request != "noidle":
             logger.debug(
-                "Client sent us %s, only %s is allowed while in " "the idle state",
+                "Client sent us %s, only %s is allowed while in the idle state",
                 repr(request),
                 repr("noidle"),
             )
             self.session.close()
             return Response([])
 
-        if not self._is_currently_idle() and self._noidle.match(request):
+        if not self._is_currently_idle() and request == "noidle":
             return Response([])  # noidle was called before idle
 
         response = self._call_next_filter(request, response, filter_chain)

--- a/src/mopidy_mpd/dispatcher.py
+++ b/src/mopidy_mpd/dispatcher.py
@@ -7,7 +7,6 @@ from typing import (
     NewType,
     TypeAlias,
     TypeVar,
-    cast,
 )
 
 import pykka
@@ -15,7 +14,6 @@ import pykka
 from mopidy_mpd import context, exceptions, protocol, tokenize, types
 
 if TYPE_CHECKING:
-    from mopidy.config import Config
     from mopidy.core import CoreProxy
 
     from mopidy_mpd.session import MpdSession
@@ -47,13 +45,12 @@ class MpdDispatcher:
 
     def __init__(
         self,
-        config: Config,
+        config: types.Config,
         core: CoreProxy,
         uri_map: MpdUriMapper,
         session: MpdSession,
     ) -> None:
         self.config = config
-        self.mpd_config = cast(types.MpdConfig, config.get("mpd", {}) if config else {})
         self.session = session
 
         self.authenticated = False
@@ -249,7 +246,7 @@ class MpdDispatcher:
     def _call_handler(self, request: str) -> protocol.Result:
         tokens = tokenize.split(request)
         # TODO: check that blacklist items are valid commands?
-        blacklist = self.mpd_config.get("command_blacklist", [])
+        blacklist = self.config["mpd"]["command_blacklist"]
         if tokens and tokens[0] in blacklist:
             logger.warning("MPD client used blacklisted command: %s", tokens[0])
             raise exceptions.MpdDisabledError(command=tokens[0])

--- a/src/mopidy_mpd/exceptions.py
+++ b/src/mopidy_mpd/exceptions.py
@@ -1,4 +1,7 @@
+from typing import Any
+
 from mopidy.exceptions import MopidyException
+from mopidy.types import UriScheme
 
 
 class MpdAckError(MopidyException):
@@ -20,13 +23,18 @@ class MpdAckError(MopidyException):
 
     error_code = 0
 
-    def __init__(self, message="", index=0, command=None):
+    def __init__(
+        self,
+        message: str = "",
+        index: int = 0,
+        command: str | None = None,
+    ) -> None:
         super().__init__(message, index, command)
         self.message = message
         self.index = index
         self.command = command
 
-    def get_mpd_ack(self):
+    def get_mpd_ack(self) -> str:
         """
         MPD error code format::
 
@@ -49,7 +57,7 @@ class MpdPasswordError(MpdAckError):
 class MpdPermissionError(MpdAckError):
     error_code = MpdAckError.ACK_ERROR_PERMISSION
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         assert self.command is not None, "command must be given explicitly"
         self.message = f'you don\'t have permission for "{self.command}"'
@@ -60,7 +68,7 @@ class MpdUnknownError(MpdAckError):
 
 
 class MpdUnknownCommandError(MpdUnknownError):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         assert self.command is not None, "command must be given explicitly"
         self.message = f'unknown command "{self.command}"'
@@ -68,7 +76,7 @@ class MpdUnknownCommandError(MpdUnknownError):
 
 
 class MpdNoCommandError(MpdUnknownCommandError):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         kwargs["command"] = ""
         super().__init__(*args, **kwargs)
         self.message = "No command given"
@@ -89,7 +97,7 @@ class MpdSystemError(MpdAckError):
 class MpdInvalidPlaylistNameError(MpdAckError):
     error_code = MpdAckError.ACK_ERROR_ARG
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.message = (
             "playlist name is invalid: playlist names may not "
@@ -100,7 +108,7 @@ class MpdInvalidPlaylistNameError(MpdAckError):
 class MpdNotImplementedError(MpdAckError):
     error_code = 0
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.message = "Not implemented"
 
@@ -109,7 +117,13 @@ class MpdInvalidTrackForPlaylistError(MpdAckError):
     # NOTE: This is a custom error for Mopidy that does not exist in MPD.
     error_code = 0
 
-    def __init__(self, playlist_scheme, track_scheme, *args, **kwargs):
+    def __init__(
+        self,
+        playlist_scheme: UriScheme,
+        track_scheme: UriScheme,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.message = (
             f'Playlist with scheme "{playlist_scheme}" '
@@ -121,7 +135,12 @@ class MpdFailedToSavePlaylistError(MpdAckError):
     # NOTE: This is a custom error for Mopidy that does not exist in MPD.
     error_code = 0
 
-    def __init__(self, backend_scheme, *args, **kwargs):
+    def __init__(
+        self,
+        backend_scheme: UriScheme,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.message = f'Backend with scheme "{backend_scheme}" failed to save playlist'
 
@@ -130,7 +149,7 @@ class MpdDisabledError(MpdAckError):
     # NOTE: This is a custom error for Mopidy that does not exist in MPD.
     error_code = 0
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         assert self.command is not None, "command must be given explicitly"
         self.message = f'"{self.command}" has been disabled in the server'

--- a/src/mopidy_mpd/formatting.py
+++ b/src/mopidy_mpd/formatting.py
@@ -1,7 +1,13 @@
-def indent(string, *, places=4, linebreak="\n", singles=False):
-    lines = string.split(linebreak)
+def indent(
+    value: str,
+    *,
+    places: int = 4,
+    linebreak: str = "\n",
+    singles: bool = False,
+) -> str:
+    lines = value.split(linebreak)
     if not singles and len(lines) == 1:
-        return string
+        return value
     for i, line in enumerate(lines):
         lines[i] = " " * places + line
     result = linebreak.join(lines)

--- a/src/mopidy_mpd/network.py
+++ b/src/mopidy_mpd/network.py
@@ -181,7 +181,7 @@ class Server:
         if unix_socket_path is not None:
             os.unlink(unix_socket_path)  # noqa: PTH108
 
-    def register_server_socket(self, fileno: int) -> Any:
+    def register_server_socket(self, fileno: int) -> int:
         return GLib.io_add_watch(fileno, GLib.IO_IN, self.handle_connection)
 
     def handle_connection(self, _fd: int, _flags: int) -> bool:
@@ -274,9 +274,9 @@ class Connection:
 
         self.stopping = False
 
-        self.recv_id = None
-        self.send_id = None
-        self.timeout_id = None
+        self.recv_id: int | None = None
+        self.send_id: int | None = None
+        self.timeout_id: int | None = None
 
         protocol_kwargs: MpdSessionKwargs = {
             "config": config,

--- a/src/mopidy_mpd/network.py
+++ b/src/mopidy_mpd/network.py
@@ -19,9 +19,9 @@ if TYPE_CHECKING:
     from collections.abc import Generator
     from types import TracebackType
 
-    from mopidy.config import Config
     from mopidy.core import CoreProxy
 
+    from mopidy_mpd import types
     from mopidy_mpd.session import MpdSession, MpdSessionKwargs
     from mopidy_mpd.types import SocketAddress
     from mopidy_mpd.uri_mapper import MpdUriMapper
@@ -126,7 +126,7 @@ class Server:
     def __init__(  # noqa: PLR0913
         self,
         *,
-        config: Config,
+        config: types.Config,
         core: CoreProxy,
         uri_map: MpdUriMapper,
         protocol: type[MpdSession],
@@ -253,7 +253,7 @@ class Connection:
     def __init__(  # noqa: PLR0913
         self,
         *,
-        config: Config,
+        config: types.Config,
         core: CoreProxy,
         uri_map: MpdUriMapper,
         protocol: type[MpdSession],

--- a/src/mopidy_mpd/network.py
+++ b/src/mopidy_mpd/network.py
@@ -329,7 +329,7 @@ class Connection:
 
     def enable_timeout(self) -> None:
         """Reactivate timeout mechanism."""
-        if self.timeout is None or self.timeout <= 0:
+        if self.timeout <= 0:
             return
 
         self.disable_timeout()

--- a/src/mopidy_mpd/network.py
+++ b/src/mopidy_mpd/network.py
@@ -11,7 +11,7 @@ import threading
 from typing import TYPE_CHECKING, Any, NoReturn
 
 import pykka
-from gi.repository import GLib
+from gi.repository import GLib  # pyright: ignore[reportMissingModuleSource]
 
 logger = logging.getLogger(__name__)
 

--- a/src/mopidy_mpd/protocol/__init__.py
+++ b/src/mopidy_mpd/protocol/__init__.py
@@ -10,12 +10,20 @@ implement our own MPD server which is compatible with the numerous existing
 `MPD clients <https://mpd.fandom.com/wiki/Clients>`_.
 """
 
+from __future__ import annotations
+
+import functools
 import inspect
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from mopidy_mpd import exceptions
 
+if TYPE_CHECKING:
+    from mopidy_mpd.dispatcher import MpdContext
+
 #: The MPD protocol uses UTF-8 for encoding all data.
-ENCODING = "UTF-8"
+ENCODING = "utf-8"
 
 #: The MPD protocol uses ``\n`` as line terminator.
 LINE_TERMINATOR = b"\n"
@@ -24,7 +32,15 @@ LINE_TERMINATOR = b"\n"
 VERSION = "0.19.0"
 
 
-def load_protocol_modules():
+ResultValue: TypeAlias = str | int
+ResultDict: TypeAlias = dict[str, ResultValue]
+ResultTuple: TypeAlias = tuple[str, ResultValue]
+ResultList: TypeAlias = list[ResultTuple | ResultDict]
+Result: TypeAlias = None | ResultDict | ResultTuple | ResultList
+Handler: TypeAlias = Callable[..., Result]
+
+
+def load_protocol_modules() -> None:
     """
     The protocol modules must be imported to get them registered in
     :attr:`commands`.
@@ -45,7 +61,7 @@ def load_protocol_modules():
     )
 
 
-def INT(value):  # noqa: N802
+def INT(value: str) -> int:  # noqa: N802
     r"""Converts a value that matches [+-]?\d+ into an integer."""
     if value is None:
         raise ValueError("None is not a valid integer")
@@ -53,7 +69,7 @@ def INT(value):  # noqa: N802
     return int(value)
 
 
-def UINT(value):  # noqa: N802
+def UINT(value: str) -> int:  # noqa: N802
     r"""Converts a value that matches \d+ into an integer."""
     if value is None:
         raise ValueError("None is not a valid integer")
@@ -62,31 +78,31 @@ def UINT(value):  # noqa: N802
     return int(value)
 
 
-def FLOAT(value):  # noqa: N802
+def FLOAT(value: str) -> float:  # noqa: N802
     r"""Converts a value that matches [+-]\d+(.\d+)? into a float."""
     if value is None:
         raise ValueError("None is not a valid float")
     return float(value)
 
 
-def UFLOAT(value):  # noqa: N802
+def UFLOAT(value: str) -> float:  # noqa: N802
     r"""Converts a value that matches \d+(.\d+)? into a float."""
     if value is None:
         raise ValueError("None is not a valid float")
-    value = float(value)
-    if value < 0:
+    result = float(value)
+    if result < 0:
         raise ValueError("Only positive numbers are allowed")
-    return value
+    return result
 
 
-def BOOL(value):  # noqa: N802
+def BOOL(value: str) -> bool:  # noqa: N802
     """Convert the values 0 and 1 into booleans."""
     if value in ("1", "0"):
         return bool(int(value))
     raise ValueError(f"{value!r} is not 0 or 1")
 
 
-def RANGE(value):  # noqa: N802
+def RANGE(value: str) -> slice:  # noqa: N802
     """Convert a single integer or range spec into a slice
 
     ``n`` should become ``slice(n, n+1)``
@@ -116,12 +132,19 @@ class Commands:
     installed into.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.handlers = {}
 
     # TODO: consider removing auth_required and list_command in favour of
     # additional command instances to register in?
-    def add(self, name, *, auth_required=True, list_command=True, **validators):  # noqa: C901
+    def add(  # noqa: C901
+        self,
+        name: str,
+        *,
+        auth_required: bool = True,
+        list_command: bool = True,
+        **validators: Callable[[str], Any],
+    ) -> Callable[[Handler], Handler]:
         """Create a decorator that registers a handler and validation rules.
 
         Additional keyword arguments are treated as converters/validators to
@@ -137,12 +160,12 @@ class Commands:
         Decorator returns the unwrapped function so that tests etc can use the
         functions with values with correct python types instead of strings.
 
-        :param string name: Name of the command being registered.
-        :param bool auth_required: If authorization is required.
-        :param bool list_command: If command should be listed in reflection.
+        :param name: Name of the command being registered.
+        :param auth_required: If authorization is required.
+        :param list_command: If command should be listed in reflection.
         """
 
-        def wrapper(func):  # noqa: C901
+        def wrapper(func: Handler) -> Handler:  # noqa: C901
             if name in self.handlers:
                 raise ValueError(f"{name} already registered")
 
@@ -167,7 +190,8 @@ class Commands:
             if spec.varkw or spec.kwonlyargs:
                 raise TypeError("Keyword arguments are not permitted")
 
-            def validate(*args, **kwargs):
+            @functools.wraps(func)
+            def validate(*args: Any, **kwargs: Any) -> Result:
                 if spec.varargs:
                     return func(*args, **kwargs)
 
@@ -197,21 +221,26 @@ class Commands:
 
         return wrapper
 
-    def call(self, tokens, context=None):
+    def call(
+        self,
+        *,
+        context: MpdContext,
+        tokens: list[str],
+    ) -> Result:
         """Find and run the handler registered for the given command.
 
         If the handler was registered with any converters/validators they will
         be run before calling the real handler.
 
-        :param list tokens: List of tokens to process
-        :param context: MPD context.
-        :type context: :class:`~mopidy_mpd.dispatcher.MpdContext`
+        :param context: MPD context
+        :param tokens: List of tokens to process
         """
         if not tokens:
             raise exceptions.MpdNoCommandError
-        if tokens[0] not in self.handlers:
-            raise exceptions.MpdUnknownCommandError(command=tokens[0])
-        return self.handlers[tokens[0]](context, *tokens[1:])
+        command, tokens = tokens[0], tokens[1:]
+        if command not in self.handlers:
+            raise exceptions.MpdUnknownCommandError(command=command)
+        return self.handlers[command](context, *tokens)
 
 
 #: Global instance to install commands into

--- a/src/mopidy_mpd/protocol/__init__.py
+++ b/src/mopidy_mpd/protocol/__init__.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 from mopidy_mpd import exceptions
 
 if TYPE_CHECKING:
-    from mopidy_mpd.dispatcher import MpdContext
+    from mopidy_mpd.context import MpdContext
 
 #: The MPD protocol uses UTF-8 for encoding all data.
 ENCODING = "utf-8"

--- a/src/mopidy_mpd/protocol/audio_output.py
+++ b/src/mopidy_mpd/protocol/audio_output.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from mopidy_mpd import exceptions, protocol
+
+if TYPE_CHECKING:
+    from mopidy_mpd.dispatcher import MpdContext
 
 
 @protocol.commands.add("disableoutput", outputid=protocol.UINT)
-def disableoutput(context, outputid):
+def disableoutput(context: MpdContext, outputid: int) -> None:
     """
     *musicpd.org, audio output section:*
 
@@ -19,7 +26,7 @@ def disableoutput(context, outputid):
 
 
 @protocol.commands.add("enableoutput", outputid=protocol.UINT)
-def enableoutput(context, outputid):
+def enableoutput(context: MpdContext, outputid: int) -> None:
     """
     *musicpd.org, audio output section:*
 
@@ -36,7 +43,7 @@ def enableoutput(context, outputid):
 
 
 @protocol.commands.add("toggleoutput", outputid=protocol.UINT)
-def toggleoutput(context, outputid):
+def toggleoutput(context: MpdContext, outputid: int) -> None:
     """
     *musicpd.org, audio output section:*
 
@@ -54,7 +61,7 @@ def toggleoutput(context, outputid):
 
 
 @protocol.commands.add("outputs")
-def outputs(context):
+def outputs(context: MpdContext) -> protocol.Result:
     """
     *musicpd.org, audio output section:*
 

--- a/src/mopidy_mpd/protocol/audio_output.py
+++ b/src/mopidy_mpd/protocol/audio_output.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from mopidy_mpd import exceptions, protocol
 
 if TYPE_CHECKING:
-    from mopidy_mpd.dispatcher import MpdContext
+    from mopidy_mpd.context import MpdContext
 
 
 @protocol.commands.add("disableoutput", outputid=protocol.UINT)

--- a/src/mopidy_mpd/protocol/channels.py
+++ b/src/mopidy_mpd/protocol/channels.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Never
 from mopidy_mpd import exceptions, protocol
 
 if TYPE_CHECKING:
-    from mopidy_mpd.dispatcher import MpdContext
+    from mopidy_mpd.context import MpdContext
 
 
 @protocol.commands.add("subscribe")

--- a/src/mopidy_mpd/protocol/channels.py
+++ b/src/mopidy_mpd/protocol/channels.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Never
+
 from mopidy_mpd import exceptions, protocol
+
+if TYPE_CHECKING:
+    from mopidy_mpd.dispatcher import MpdContext
 
 
 @protocol.commands.add("subscribe")
-def subscribe(context, channel):
+def subscribe(context: MpdContext, channel: str) -> Never:
     """
     *musicpd.org, client to client section:*
 
@@ -17,7 +24,7 @@ def subscribe(context, channel):
 
 
 @protocol.commands.add("unsubscribe")
-def unsubscribe(context, channel):
+def unsubscribe(context: MpdContext, channel: str) -> Never:
     """
     *musicpd.org, client to client section:*
 
@@ -30,7 +37,7 @@ def unsubscribe(context, channel):
 
 
 @protocol.commands.add("channels")
-def channels(context):
+def channels(context: MpdContext) -> Never:
     """
     *musicpd.org, client to client section:*
 
@@ -43,7 +50,7 @@ def channels(context):
 
 
 @protocol.commands.add("readmessages")
-def readmessages(context):
+def readmessages(context: MpdContext) -> Never:
     """
     *musicpd.org, client to client section:*
 
@@ -56,7 +63,7 @@ def readmessages(context):
 
 
 @protocol.commands.add("sendmessage")
-def sendmessage(context, channel, text):
+def sendmessage(context: MpdContext, channel: str, text: str) -> Never:
     """
     *musicpd.org, client to client section:*
 

--- a/src/mopidy_mpd/protocol/command_list.py
+++ b/src/mopidy_mpd/protocol/command_list.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from mopidy_mpd import exceptions, protocol
+
+if TYPE_CHECKING:
+    from mopidy_mpd.dispatcher import MpdContext
 
 
 @protocol.commands.add("command_list_begin", list_command=False)
-def command_list_begin(context):
+def command_list_begin(context: MpdContext) -> None:
     """
     *musicpd.org, command list section:*
 
@@ -24,7 +31,7 @@ def command_list_begin(context):
 
 
 @protocol.commands.add("command_list_end", list_command=False)
-def command_list_end(context):
+def command_list_end(context: MpdContext) -> protocol.Result:
     """See :meth:`command_list_begin()`."""
     # TODO: batch consecutive add commands
     if not context.dispatcher.command_list_receiving:
@@ -52,7 +59,7 @@ def command_list_end(context):
 
 
 @protocol.commands.add("command_list_ok_begin", list_command=False)
-def command_list_ok_begin(context):
+def command_list_ok_begin(context: MpdContext) -> None:
     """See :meth:`command_list_begin()`."""
     context.dispatcher.command_list_receiving = True
     context.dispatcher.command_list_ok = True

--- a/src/mopidy_mpd/protocol/command_list.py
+++ b/src/mopidy_mpd/protocol/command_list.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from mopidy_mpd import exceptions, protocol
 
 if TYPE_CHECKING:
-    from mopidy_mpd.dispatcher import MpdContext
+    from mopidy_mpd.context import MpdContext
 
 
 @protocol.commands.add("command_list_begin", list_command=False)

--- a/src/mopidy_mpd/protocol/connection.py
+++ b/src/mopidy_mpd/protocol/connection.py
@@ -61,7 +61,7 @@ def ping(context: MpdContext) -> None:
 
 
 @protocol.commands.add("tagtypes")
-def tagtypes(context: MpdContext, *parameters: list[str]) -> protocol.Result:
+def tagtypes(context: MpdContext, *args: str) -> protocol.Result:
     """
     *mpd.readthedocs.io, connection settings section:*
 
@@ -85,7 +85,7 @@ def tagtypes(context: MpdContext, *parameters: list[str]) -> protocol.Result:
 
         Announce that this client is interested in all tag types.
     """
-    parameters = list(parameters)
+    parameters = list(args)
     if parameters:
         subcommand = parameters.pop(0).lower()
         match subcommand:

--- a/src/mopidy_mpd/protocol/connection.py
+++ b/src/mopidy_mpd/protocol/connection.py
@@ -6,7 +6,7 @@ from mopidy_mpd import exceptions, protocol
 from mopidy_mpd.protocol import tagtype_list
 
 if TYPE_CHECKING:
-    from mopidy_mpd.dispatcher import MpdContext
+    from mopidy_mpd.context import MpdContext
 
 
 @protocol.commands.add("close", auth_required=False)

--- a/src/mopidy_mpd/protocol/connection.py
+++ b/src/mopidy_mpd/protocol/connection.py
@@ -1,9 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Never
+
 from mopidy_mpd import exceptions, protocol
 from mopidy_mpd.protocol import tagtype_list
 
+if TYPE_CHECKING:
+    from mopidy_mpd.dispatcher import MpdContext
+
 
 @protocol.commands.add("close", auth_required=False)
-def close(context):
+def close(context: MpdContext) -> None:
     """
     *musicpd.org, connection section:*
 
@@ -15,7 +22,7 @@ def close(context):
 
 
 @protocol.commands.add("kill", list_command=False)
-def kill(context):
+def kill(context: MpdContext) -> Never:
     """
     *musicpd.org, connection section:*
 
@@ -27,7 +34,7 @@ def kill(context):
 
 
 @protocol.commands.add("password", auth_required=False)
-def password(context, password):
+def password(context: MpdContext, password: str) -> None:
     """
     *musicpd.org, connection section:*
 
@@ -43,7 +50,7 @@ def password(context, password):
 
 
 @protocol.commands.add("ping", auth_required=False)
-def ping(context):
+def ping(context: MpdContext) -> None:
     """
     *musicpd.org, connection section:*
 
@@ -54,7 +61,7 @@ def ping(context):
 
 
 @protocol.commands.add("tagtypes")
-def tagtypes(context, *parameters):
+def tagtypes(context: MpdContext, *parameters: list[str]) -> protocol.Result:
     """
     *mpd.readthedocs.io, connection settings section:*
 
@@ -98,7 +105,7 @@ def tagtypes(context, *parameters):
     return [("tagtype", tagtype) for tagtype in context.session.tagtypes]
 
 
-def _validate_tagtypes(parameters):
+def _validate_tagtypes(parameters: list[str]) -> None:
     param_set = set(parameters)
     if not param_set:
         raise exceptions.MpdArgError("Not enough arguments")

--- a/src/mopidy_mpd/protocol/connection.py
+++ b/src/mopidy_mpd/protocol/connection.py
@@ -43,7 +43,7 @@ def password(context: MpdContext, password: str) -> None:
         This is used for authentication with the server. ``PASSWORD`` is
         simply the plaintext password.
     """
-    if password == context.password:
+    if password == context.config["mpd"]["password"]:
         context.dispatcher.authenticated = True
     else:
         raise exceptions.MpdPasswordError("incorrect password")

--- a/src/mopidy_mpd/protocol/current_playlist.py
+++ b/src/mopidy_mpd/protocol/current_playlist.py
@@ -35,7 +35,7 @@ def add(context: MpdContext, uri: Uri) -> None:
 
     try:
         uris = []
-        for _path, ref in context.browse(uri, lookup=False):
+        for _path, ref in context.browse(uri, recursive=True, lookup=False):
             if ref:
                 uris.append(ref.uri)
     except exceptions.MpdNoExistError as exc:
@@ -303,12 +303,13 @@ def plchanges(context: MpdContext, version: int) -> protocol.Result:
 
         tl_track = context.core.playback.get_current_tl_track().get()
         position = context.core.tracklist.index(tl_track).get()
-        return translator.track_to_mpd_format(
-            tl_track,
-            context.session.tagtypes,
-            position=position,
-            stream_title=stream_title,
-        )
+        if tl_track is not None and position is not None:
+            return translator.track_to_mpd_format(
+                tl_track,
+                context.session.tagtypes,
+                position=position,
+                stream_title=stream_title,
+            )
 
     return None
 

--- a/src/mopidy_mpd/protocol/current_playlist.py
+++ b/src/mopidy_mpd/protocol/current_playlist.py
@@ -8,7 +8,7 @@ from mopidy_mpd import exceptions, protocol, translator
 if TYPE_CHECKING:
     from mopidy.types import Uri
 
-    from mopidy_mpd.dispatcher import MpdContext
+    from mopidy_mpd.context import MpdContext
 
 
 @protocol.commands.add("add")

--- a/src/mopidy_mpd/protocol/current_playlist.py
+++ b/src/mopidy_mpd/protocol/current_playlist.py
@@ -341,7 +341,7 @@ def plchangesposid(context: MpdContext, version: int) -> protocol.Result:
 
 
 @protocol.commands.add("prio", priority=protocol.UINT, position=protocol.RANGE)
-def prio(context: MpdContext, priority: int, position: int) -> protocol.Result:
+def prio(context: MpdContext, priority: int, position: slice) -> protocol.Result:
     """
     *musicpd.org, current playlist section:*
 

--- a/src/mopidy_mpd/protocol/current_playlist.py
+++ b/src/mopidy_mpd/protocol/current_playlist.py
@@ -1,10 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from mopidy_mpd import exceptions, protocol, translator
 
+if TYPE_CHECKING:
+    from mopidy.types import Uri
+
+    from mopidy_mpd.dispatcher import MpdContext
+
 
 @protocol.commands.add("add")
-def add(context, uri):
+def add(context: MpdContext, uri: Uri) -> None:
     """
     *musicpd.org, current playlist section:*
 
@@ -40,7 +48,7 @@ def add(context, uri):
 
 
 @protocol.commands.add("addid", songpos=protocol.UINT)
-def addid(context, uri, songpos=None):
+def addid(context: MpdContext, uri: Uri, songpos: int | None = None) -> protocol.Result:
     """
     *musicpd.org, current playlist section:*
 
@@ -73,7 +81,7 @@ def addid(context, uri, songpos=None):
 
 
 @protocol.commands.add("delete", songrange=protocol.RANGE)
-def delete(context, songrange):
+def delete(context: MpdContext, songrange: slice) -> None:
     """
     *musicpd.org, current playlist section:*
 
@@ -88,12 +96,11 @@ def delete(context, songrange):
     tl_tracks = context.core.tracklist.slice(start, end).get()
     if not tl_tracks:
         raise exceptions.MpdArgError("Bad song index", command="delete")
-    for tlid, _ in tl_tracks:
-        context.core.tracklist.remove({"tlid": [tlid]})
+    context.core.tracklist.remove({"tlid": [tl_track.tlid for tl_track in tl_tracks]})
 
 
 @protocol.commands.add("deleteid", tlid=protocol.UINT)
-def deleteid(context, tlid):
+def deleteid(context: MpdContext, tlid: int) -> None:
     """
     *musicpd.org, current playlist section:*
 
@@ -107,7 +114,7 @@ def deleteid(context, tlid):
 
 
 @protocol.commands.add("clear")
-def clear(context):
+def clear(context: MpdContext) -> None:
     """
     *musicpd.org, current playlist section:*
 
@@ -119,7 +126,7 @@ def clear(context):
 
 
 @protocol.commands.add("move", songrange=protocol.RANGE, to=protocol.UINT)
-def move_range(context, songrange, to):
+def move_range(context: MpdContext, songrange: slice, to: int) -> None:
     """
     *musicpd.org, current playlist section:*
 
@@ -136,7 +143,7 @@ def move_range(context, songrange, to):
 
 
 @protocol.commands.add("moveid", tlid=protocol.UINT, to=protocol.UINT)
-def moveid(context, tlid, to):
+def moveid(context: MpdContext, tlid: int, to: int) -> None:
     """
     *musicpd.org, current playlist section:*
 
@@ -146,15 +153,14 @@ def moveid(context, tlid, to):
         the playlist. If ``TO`` is negative, it is relative to the current
         song in the playlist (if there is one).
     """
-    tl_tracks = context.core.tracklist.filter({"tlid": [tlid]}).get()
-    if not tl_tracks:
+    position = context.core.tracklist.index(tlid=tlid).get()
+    if position is None:
         raise exceptions.MpdNoExistError("No such song")
-    position = context.core.tracklist.index(tl_tracks[0]).get()
     context.core.tracklist.move(position, position + 1, to)
 
 
 @protocol.commands.add("playlist")
-def playlist(context):
+def playlist(context: MpdContext) -> protocol.Result:
     """
     *musicpd.org, current playlist section:*
 
@@ -170,7 +176,7 @@ def playlist(context):
 
 
 @protocol.commands.add("playlistfind")
-def playlistfind(context, tag, needle):
+def playlistfind(context: MpdContext, tag: str, needle: str) -> protocol.Result:
     """
     *musicpd.org, current playlist section:*
 
@@ -190,7 +196,7 @@ def playlistfind(context, tag, needle):
 
 
 @protocol.commands.add("playlistid", tlid=protocol.UINT)
-def playlistid(context, tlid=None):
+def playlistid(context: MpdContext, tlid: int | None = None) -> protocol.Result:
     """
     *musicpd.org, current playlist section:*
 
@@ -215,7 +221,7 @@ def playlistid(context, tlid=None):
 
 
 @protocol.commands.add("playlistinfo")
-def playlistinfo(context, parameter=None):
+def playlistinfo(context: MpdContext, parameter: str | None = None) -> protocol.Result:
     """
     *musicpd.org, current playlist section:*
 
@@ -247,7 +253,7 @@ def playlistinfo(context, parameter=None):
 
 
 @protocol.commands.add("playlistsearch")
-def playlistsearch(context, tag, needle):
+def playlistsearch(context: MpdContext, tag: str, needle: str) -> protocol.Result:
     """
     *musicpd.org, current playlist section:*
 
@@ -264,7 +270,7 @@ def playlistsearch(context, tag, needle):
 
 
 @protocol.commands.add("plchanges", version=protocol.INT)
-def plchanges(context, version):
+def plchanges(context: MpdContext, version: int) -> protocol.Result:
     """
     *musicpd.org, current playlist section:*
 
@@ -308,7 +314,7 @@ def plchanges(context, version):
 
 
 @protocol.commands.add("plchangesposid", version=protocol.INT)
-def plchangesposid(context, version):
+def plchangesposid(context: MpdContext, version: int) -> protocol.Result:
     """
     *musicpd.org, current playlist section:*
 
@@ -334,7 +340,7 @@ def plchangesposid(context, version):
 
 
 @protocol.commands.add("prio", priority=protocol.UINT, position=protocol.RANGE)
-def prio(context, priority, position):
+def prio(context: MpdContext, priority: int, position: int) -> protocol.Result:
     """
     *musicpd.org, current playlist section:*
 
@@ -350,7 +356,7 @@ def prio(context, priority, position):
 
 
 @protocol.commands.add("prioid")
-def prioid(context, *args):
+def prioid(context: MpdContext, *args: str) -> protocol.Result:
     """
     *musicpd.org, current playlist section:*
 
@@ -362,7 +368,7 @@ def prioid(context, *args):
 
 
 @protocol.commands.add("rangeid", tlid=protocol.UINT, songrange=protocol.RANGE)
-def rangeid(context, tlid, songrange):
+def rangeid(context: MpdContext, tlid: int, songrange: slice) -> protocol.Result:
     """
     *musicpd.org, current playlist section:*
 
@@ -381,7 +387,7 @@ def rangeid(context, tlid, songrange):
 
 
 @protocol.commands.add("shuffle", songrange=protocol.RANGE)
-def shuffle(context, songrange=None):
+def shuffle(context: MpdContext, songrange: slice | None = None) -> None:
     """
     *musicpd.org, current playlist section:*
 
@@ -398,7 +404,7 @@ def shuffle(context, songrange=None):
 
 
 @protocol.commands.add("swap", songpos1=protocol.UINT, songpos2=protocol.UINT)
-def swap(context, songpos1, songpos2):
+def swap(context: MpdContext, songpos1: int, songpos2: int) -> None:
     """
     *musicpd.org, current playlist section:*
 
@@ -413,7 +419,7 @@ def swap(context, songpos1, songpos2):
 
 
 @protocol.commands.add("swapid", tlid1=protocol.UINT, tlid2=protocol.UINT)
-def swapid(context, tlid1, tlid2):
+def swapid(context: MpdContext, tlid1: int, tlid2: int) -> None:
     """
     *musicpd.org, current playlist section:*
 
@@ -421,17 +427,15 @@ def swapid(context, tlid1, tlid2):
 
         Swaps the positions of ``SONG1`` and ``SONG2`` (both song ids).
     """
-    tl_tracks1 = context.core.tracklist.filter({"tlid": [tlid1]}).get()
-    tl_tracks2 = context.core.tracklist.filter({"tlid": [tlid2]}).get()
-    if not tl_tracks1 or not tl_tracks2:
+    position1 = context.core.tracklist.index(tlid=tlid1).get()
+    position2 = context.core.tracklist.index(tlid=tlid2).get()
+    if position1 is None or position2 is None:
         raise exceptions.MpdNoExistError("No such song")
-    position1 = context.core.tracklist.index(tl_tracks1[0]).get()
-    position2 = context.core.tracklist.index(tl_tracks2[0]).get()
     swap(context, position1, position2)
 
 
 @protocol.commands.add("addtagid", tlid=protocol.UINT)
-def addtagid(context, tlid, tag, value):
+def addtagid(context: MpdContext, tlid: int, tag: str, value: str) -> protocol.Result:
     """
     *musicpd.org, current playlist section:*
 
@@ -449,7 +453,7 @@ def addtagid(context, tlid, tag, value):
 
 
 @protocol.commands.add("cleartagid", tlid=protocol.UINT)
-def cleartagid(context, tlid, tag):
+def cleartagid(context: MpdContext, tlid: int, tag: str) -> protocol.Result:
     """
     *musicpd.org, current playlist section:*
 

--- a/src/mopidy_mpd/protocol/mount.py
+++ b/src/mopidy_mpd/protocol/mount.py
@@ -7,7 +7,7 @@ from mopidy_mpd import exceptions, protocol
 if TYPE_CHECKING:
     from mopidy.types import Uri
 
-    from mopidy_mpd.dispatcher import MpdContext
+    from mopidy_mpd.context import MpdContext
 
 
 @protocol.commands.add("mount")

--- a/src/mopidy_mpd/protocol/mount.py
+++ b/src/mopidy_mpd/protocol/mount.py
@@ -1,8 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Never
+
 from mopidy_mpd import exceptions, protocol
+
+if TYPE_CHECKING:
+    from mopidy.types import Uri
+
+    from mopidy_mpd.dispatcher import MpdContext
 
 
 @protocol.commands.add("mount")
-def mount(context, path, uri):
+def mount(context: MpdContext, path: str, uri: Uri) -> Never:
     """
     *musicpd.org, mounts and neighbors section:*
 
@@ -19,7 +28,7 @@ def mount(context, path, uri):
 
 
 @protocol.commands.add("unmount")
-def unmount(context, path):
+def unmount(context: MpdContext, path: str) -> Never:
     """
     *musicpd.org, mounts and neighbors section:*
 
@@ -36,7 +45,7 @@ def unmount(context, path):
 
 
 @protocol.commands.add("listmounts")
-def listmounts(context):
+def listmounts(context: MpdContext) -> Never:
     """
     *musicpd.org, mounts and neighbors section:*
 
@@ -59,7 +68,7 @@ def listmounts(context):
 
 
 @protocol.commands.add("listneighbors")
-def listneighbors(context):
+def listneighbors(context: MpdContext) -> Never:
     """
     *musicpd.org, mounts and neighbors section:*
 

--- a/src/mopidy_mpd/protocol/music_db.py
+++ b/src/mopidy_mpd/protocol/music_db.py
@@ -7,6 +7,7 @@ from mopidy.models import Album, Artist, SearchResult, Track
 from mopidy.types import DistinctField, Query, SearchField, Uri
 
 from mopidy_mpd import exceptions, protocol, translator
+from mopidy_mpd.protocol import stored_playlists
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -317,7 +318,7 @@ def listall(context: MpdContext, uri: str | None = None) -> protocol.Result:
     .. warning:: This command is disabled by default in Mopidy installs.
     """
     result = []
-    for path, track_ref in context.browse(uri, lookup=False):
+    for path, track_ref in context.browse(uri, recursive=True, lookup=False):
         if not track_ref:
             result.append(("directory", path.lstrip("/")))
         else:
@@ -346,7 +347,7 @@ def listallinfo(context: MpdContext, uri: str | None = None) -> protocol.Result:
     .. warning:: This command is disabled by default in Mopidy installs.
     """
     result: protocol.ResultList = []
-    for path, lookup_future in context.browse(uri, lookup=True):
+    for path, lookup_future in context.browse(uri, recursive=True, lookup=True):
         if not lookup_future:
             result.append(("directory", path.lstrip("/")))
         else:
@@ -399,7 +400,7 @@ def lsinfo(context: MpdContext, uri: str | None = None) -> protocol.Result:
     directories located at the root level, for both ``lsinfo``, ``lsinfo
     ""``, and ``lsinfo "/"``.
     """
-    result = []
+    result: protocol.ResultList = []
     for path, lookup_future in context.browse(uri, recursive=False, lookup=True):
         if not lookup_future:
             result.append(("directory", path.lstrip("/")))
@@ -413,7 +414,7 @@ def lsinfo(context: MpdContext, uri: str | None = None) -> protocol.Result:
                     )
 
     if uri in (None, "", "/"):
-        result.extend(protocol.stored_playlists.listplaylists(context))
+        result.extend(stored_playlists.listplaylists(context))
 
     return result
 

--- a/src/mopidy_mpd/protocol/music_db.py
+++ b/src/mopidy_mpd/protocol/music_db.py
@@ -414,7 +414,15 @@ def lsinfo(context: MpdContext, uri: str | None = None) -> protocol.Result:
                     )
 
     if uri in (None, "", "/"):
-        result.extend(stored_playlists.listplaylists(context))
+        result.extend(
+            # We know that `listplaylists`` returns this specific variant of
+            # `protocol.Result``, but this information disappears because of the
+            # typing of the `protocol.commands.add()`` decorator.
+            cast(
+                protocol.ResultList,
+                stored_playlists.listplaylists(context),
+            )
+        )
 
     return result
 

--- a/src/mopidy_mpd/protocol/music_db.py
+++ b/src/mopidy_mpd/protocol/music_db.py
@@ -12,7 +12,7 @@ from mopidy_mpd.protocol import stored_playlists
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
-    from mopidy_mpd.dispatcher import MpdContext
+    from mopidy_mpd.context import MpdContext
 
 
 _LIST_MAPPING: dict[str, DistinctField] = {

--- a/src/mopidy_mpd/protocol/playback.py
+++ b/src/mopidy_mpd/protocol/playback.py
@@ -8,7 +8,7 @@ from mopidy.types import DurationMs, Percentage
 from mopidy_mpd import exceptions, protocol
 
 if TYPE_CHECKING:
-    from mopidy_mpd.dispatcher import MpdContext
+    from mopidy_mpd.context import MpdContext
 
 
 @protocol.commands.add("consume", state=protocol.BOOL)

--- a/src/mopidy_mpd/protocol/playback.py
+++ b/src/mopidy_mpd/protocol/playback.py
@@ -1,10 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Never
+
 from mopidy.core import PlaybackState
+from mopidy.types import DurationMs, Percentage
 
 from mopidy_mpd import exceptions, protocol
 
+if TYPE_CHECKING:
+    from mopidy_mpd.dispatcher import MpdContext
+
 
 @protocol.commands.add("consume", state=protocol.BOOL)
-def consume(context, state):
+def consume(context: MpdContext, state: bool) -> None:  # noqa: FBT001
     """
     *musicpd.org, playback section:*
 
@@ -18,7 +26,7 @@ def consume(context, state):
 
 
 @protocol.commands.add("crossfade", seconds=protocol.UINT)
-def crossfade(context, seconds):
+def crossfade(context: MpdContext, seconds: int) -> Never:
     """
     *musicpd.org, playback section:*
 
@@ -30,7 +38,7 @@ def crossfade(context, seconds):
 
 
 @protocol.commands.add("mixrampdb")
-def mixrampdb(context, decibels):
+def mixrampdb(context: MpdContext, decibels: str) -> Never:
     """
     *musicpd.org, playback section:*
 
@@ -47,7 +55,7 @@ def mixrampdb(context, decibels):
 
 
 @protocol.commands.add("mixrampdelay", seconds=protocol.UINT)
-def mixrampdelay(context, seconds):
+def mixrampdelay(context: MpdContext, seconds: int) -> Never:
     """
     *musicpd.org, playback section:*
 
@@ -61,7 +69,7 @@ def mixrampdelay(context, seconds):
 
 
 @protocol.commands.add("next")
-def next_(context):
+def next_(context: MpdContext) -> None:
     """
     *musicpd.org, playback section:*
 
@@ -115,11 +123,11 @@ def next_(context):
           order as the first time.
 
     """
-    return context.core.playback.next().get()
+    context.core.playback.next().get()
 
 
 @protocol.commands.add("pause", state=protocol.BOOL)
-def pause(context, state=None):
+def pause(context: MpdContext, state: bool | None = None) -> None:
     """
     *musicpd.org, playback section:*
 
@@ -131,21 +139,22 @@ def pause(context, state=None):
 
     - Calls ``pause`` without any arguments to toogle pause.
     """
-    if state is None:
-        # Deprecated: Calling `pause` without any arguments
-        playback_state = context.core.playback.get_state().get()
-        if playback_state == PlaybackState.PLAYING:
+    match state:
+        case None:
+            # Deprecated: Calling `pause` without any arguments
+            playback_state = context.core.playback.get_state().get()
+            if playback_state == PlaybackState.PLAYING:
+                context.core.playback.pause().get()
+            elif playback_state == PlaybackState.PAUSED:
+                context.core.playback.resume().get()
+        case True:
             context.core.playback.pause().get()
-        elif playback_state == PlaybackState.PAUSED:
+        case False:
             context.core.playback.resume().get()
-    elif state:
-        context.core.playback.pause().get()
-    else:
-        context.core.playback.resume().get()
 
 
 @protocol.commands.add("play", songpos=protocol.INT)
-def play(context, songpos=None):
+def play(context: MpdContext, songpos: int | None = None) -> None:
     """
     *musicpd.org, playback section:*
 
@@ -170,38 +179,42 @@ def play(context, songpos=None):
     - issues ``play 6`` without quotes around the argument.
     """
     if songpos is None:
-        return context.core.playback.play().get()
+        context.core.playback.play().get()
+        return
 
     if songpos == -1:
-        return _play_minus_one(context)
+        _play_minus_one(context)
+        return
 
     try:
         tl_track = context.core.tracklist.slice(songpos, songpos + 1).get()[0]
-        return context.core.playback.play(tlid=tl_track.tlid).get()
+        context.core.playback.play(tlid=tl_track.tlid).get()
     except IndexError as exc:
         raise exceptions.MpdArgError("Bad song index") from exc
 
 
-def _play_minus_one(context):
-    playback_state = context.core.playback.get_state().get()
-    if playback_state == PlaybackState.PLAYING:
-        return None  # Nothing to do
-    if playback_state == PlaybackState.PAUSED:
-        return context.core.playback.resume().get()
+def _play_minus_one(context: MpdContext) -> None:
+    match context.core.playback.get_state().get():
+        case PlaybackState.PLAYING:
+            pass  # Nothing to do
+        case PlaybackState.PAUSED:
+            context.core.playback.resume().get()
+        case PlaybackState.STOPPED:
+            current_tlid = context.core.playback.get_current_tlid().get()
+            if current_tlid is not None:
+                context.core.playback.play(tlid=current_tlid).get()
+                return
 
-    current_tl_track = context.core.playback.get_current_tl_track().get()
-    if current_tl_track is not None:
-        return context.core.playback.play(tlid=current_tl_track.tlid).get()
+            tl_tracks = context.core.tracklist.slice(0, 1).get()
+            if tl_tracks:
+                context.core.playback.play(tlid=tl_tracks[0].tlid).get()
+                return
 
-    tl_tracks = context.core.tracklist.slice(0, 1).get()
-    if tl_tracks:
-        return context.core.playback.play(tlid=tl_tracks[0].tlid).get()
-
-    return None  # Fail silently
+            # No current track, empty tracklist: nothing to do
 
 
 @protocol.commands.add("playid", tlid=protocol.INT)
-def playid(context, tlid):
+def playid(context: MpdContext, tlid: int) -> None:
     """
     *musicpd.org, playback section:*
 
@@ -220,6 +233,7 @@ def playid(context, tlid):
     """
     if tlid == -1:
         return _play_minus_one(context)
+
     tl_tracks = context.core.tracklist.filter({"tlid": [tlid]}).get()
     if not tl_tracks:
         raise exceptions.MpdNoExistError("No such song")
@@ -227,7 +241,7 @@ def playid(context, tlid):
 
 
 @protocol.commands.add("previous")
-def previous(context):
+def previous(context: MpdContext) -> None:
     """
     *musicpd.org, playback section:*
 
@@ -270,11 +284,11 @@ def previous(context):
           ``previous`` should do a seek to time position 0.
 
     """
-    return context.core.playback.previous().get()
+    context.core.playback.previous().get()
 
 
 @protocol.commands.add("random", state=protocol.BOOL)
-def random(context, state):
+def random(context: MpdContext, state: bool) -> None:  # noqa: FBT001
     """
     *musicpd.org, playback section:*
 
@@ -286,7 +300,7 @@ def random(context, state):
 
 
 @protocol.commands.add("repeat", state=protocol.BOOL)
-def repeat(context, state):
+def repeat(context: MpdContext, state: bool) -> None:  # noqa: FBT001
     """
     *musicpd.org, playback section:*
 
@@ -298,7 +312,7 @@ def repeat(context, state):
 
 
 @protocol.commands.add("replay_gain_mode")
-def replay_gain_mode(context, mode):
+def replay_gain_mode(context: MpdContext, mode: str) -> Never:
     """
     *musicpd.org, playback section:*
 
@@ -315,7 +329,7 @@ def replay_gain_mode(context, mode):
 
 
 @protocol.commands.add("replay_gain_status")
-def replay_gain_status(context):
+def replay_gain_status(context: MpdContext) -> str:
     """
     *musicpd.org, playback section:*
 
@@ -328,7 +342,7 @@ def replay_gain_status(context):
 
 
 @protocol.commands.add("seek", songpos=protocol.UINT, seconds=protocol.UFLOAT)
-def seek(context, songpos, seconds):
+def seek(context: MpdContext, songpos: int, seconds: float) -> None:
     """
     *musicpd.org, playback section:*
 
@@ -343,12 +357,12 @@ def seek(context, songpos, seconds):
     """
     tl_track = context.core.playback.get_current_tl_track().get()
     if context.core.tracklist.index(tl_track).get() != songpos:
-        play(context, songpos)
-    context.core.playback.seek(int(seconds * 1000)).get()
+        play(context, songpos=songpos)
+    context.core.playback.seek(DurationMs(int(seconds * 1000))).get()
 
 
 @protocol.commands.add("seekid", tlid=protocol.UINT, seconds=protocol.UFLOAT)
-def seekid(context, tlid, seconds):
+def seekid(context: MpdContext, tlid: int, seconds: float) -> None:
     """
     *musicpd.org, playback section:*
 
@@ -358,12 +372,12 @@ def seekid(context, tlid, seconds):
     """
     tl_track = context.core.playback.get_current_tl_track().get()
     if not tl_track or tl_track.tlid != tlid:
-        playid(context, tlid)
-    context.core.playback.seek(int(seconds * 1000)).get()
+        playid(context, tlid=tlid)
+    context.core.playback.seek(DurationMs(int(seconds * 1000))).get()
 
 
 @protocol.commands.add("seekcur")
-def seekcur(context, time):
+def seekcur(context: MpdContext, time: str) -> None:
     """
     *musicpd.org, playback section:*
 
@@ -374,15 +388,15 @@ def seekcur(context, time):
     """
     if time.startswith(("+", "-")):
         position = context.core.playback.get_time_position().get()
-        position += int(protocol.FLOAT(time) * 1000)
+        position = DurationMs(position + int(protocol.FLOAT(time) * 1000))
         context.core.playback.seek(position).get()
     else:
-        position = int(protocol.UFLOAT(time) * 1000)
+        position = DurationMs(int(protocol.UFLOAT(time) * 1000))
         context.core.playback.seek(position).get()
 
 
 @protocol.commands.add("setvol", volume=protocol.INT)
-def setvol(context, volume):
+def setvol(context: MpdContext, volume: int) -> None:
     """
     *musicpd.org, playback section:*
 
@@ -395,14 +409,14 @@ def setvol(context, volume):
     - issues ``setvol 50`` without quotes around the argument.
     """
     # NOTE: we use INT as clients can pass in +N etc.
-    value = min(max(0, volume), 100)
+    value = Percentage(min(max(0, volume), 100))
     success = context.core.mixer.set_volume(value).get()
     if not success:
         raise exceptions.MpdSystemError("problems setting volume")
 
 
 @protocol.commands.add("single", state=protocol.BOOL)
-def single(context, state):
+def single(context: MpdContext, state: bool) -> None:  # noqa: FBT001
     """
     *musicpd.org, playback section:*
 
@@ -416,7 +430,7 @@ def single(context, state):
 
 
 @protocol.commands.add("stop")
-def stop(context):
+def stop(context: MpdContext) -> None:
     """
     *musicpd.org, playback section:*
 
@@ -428,7 +442,7 @@ def stop(context):
 
 
 @protocol.commands.add("volume", change=protocol.INT)
-def volume(context, change):
+def volume(context: MpdContext, change: int) -> None:
     """
     *musicpd.org, playback section:*
 
@@ -450,7 +464,7 @@ def volume(context, change):
     if old_volume is None:
         raise exceptions.MpdSystemError("problems setting volume")
 
-    new_volume = min(max(min_volume, old_volume + change), max_volume)
+    new_volume = Percentage(min(max(min_volume, old_volume + change), max_volume))
     success = context.core.mixer.set_volume(new_volume).get()
     if not success:
         raise exceptions.MpdSystemError("problems setting volume")

--- a/src/mopidy_mpd/protocol/playback.py
+++ b/src/mopidy_mpd/protocol/playback.py
@@ -329,7 +329,7 @@ def replay_gain_mode(context: MpdContext, mode: str) -> Never:
 
 
 @protocol.commands.add("replay_gain_status")
-def replay_gain_status(context: MpdContext) -> str:
+def replay_gain_status(context: MpdContext) -> protocol.Result:
     """
     *musicpd.org, playback section:*
 
@@ -338,7 +338,7 @@ def replay_gain_status(context: MpdContext) -> str:
         Prints replay gain options. Currently, only the variable
         ``replay_gain_mode`` is returned.
     """
-    return "replay_gain_mode: off"  # TODO
+    return ("replay_gain_mode", "off")  # TODO
 
 
 @protocol.commands.add("seek", songpos=protocol.UINT, seconds=protocol.UFLOAT)

--- a/src/mopidy_mpd/protocol/playback.py
+++ b/src/mopidy_mpd/protocol/playback.py
@@ -232,12 +232,13 @@ def playid(context: MpdContext, tlid: int) -> None:
       replacement, starts playback at the first track.
     """
     if tlid == -1:
-        return _play_minus_one(context)
+        _play_minus_one(context)
+        return
 
     tl_tracks = context.core.tracklist.filter({"tlid": [tlid]}).get()
     if not tl_tracks:
         raise exceptions.MpdNoExistError("No such song")
-    return context.core.playback.play(tlid=tl_tracks[0].tlid).get()
+    context.core.playback.play(tlid=tl_tracks[0].tlid).get()
 
 
 @protocol.commands.add("previous")

--- a/src/mopidy_mpd/protocol/reflection.py
+++ b/src/mopidy_mpd/protocol/reflection.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Never
+
 from mopidy_mpd import exceptions, protocol
+
+if TYPE_CHECKING:
+    from mopidy_mpd.dispatcher import MpdContext
 
 
 @protocol.commands.add("config", list_command=False)
-def config(context):
+def config(context: MpdContext) -> Never:
     """
     *musicpd.org, reflection section:*
 
@@ -16,7 +23,7 @@ def config(context):
 
 
 @protocol.commands.add("commands", auth_required=False)
-def commands(context):
+def commands(context: MpdContext) -> protocol.Result:
     """
     *musicpd.org, reflection section:*
 
@@ -35,7 +42,7 @@ def commands(context):
 
 
 @protocol.commands.add("decoders")
-def decoders(context):
+def decoders(context: MpdContext) -> None:
     """
     *musicpd.org, reflection section:*
 
@@ -62,7 +69,7 @@ def decoders(context):
 
 
 @protocol.commands.add("notcommands", auth_required=False)
-def notcommands(context):
+def notcommands(context: MpdContext) -> protocol.Result:
     """
     *musicpd.org, reflection section:*
 
@@ -81,7 +88,7 @@ def notcommands(context):
 
 
 @protocol.commands.add("urlhandlers")
-def urlhandlers(context):
+def urlhandlers(context: MpdContext) -> protocol.Result:
     """
     *musicpd.org, reflection section:*
 

--- a/src/mopidy_mpd/protocol/reflection.py
+++ b/src/mopidy_mpd/protocol/reflection.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Never
 from mopidy_mpd import exceptions, protocol
 
 if TYPE_CHECKING:
-    from mopidy_mpd.dispatcher import MpdContext
+    from mopidy_mpd.context import MpdContext
 
 
 @protocol.commands.add("config", list_command=False)

--- a/src/mopidy_mpd/protocol/status.py
+++ b/src/mopidy_mpd/protocol/status.py
@@ -101,16 +101,18 @@ def idle(context: MpdContext, *args: str) -> protocol.Result:
     subsystems = list(args) if args else SUBSYSTEMS
 
     for subsystem in subsystems:
-        context.subscriptions.add(subsystem)
+        context.dispatcher.subsystem_subscriptions.add(subsystem)
 
-    active = context.subscriptions.intersection(context.events)
+    active = context.dispatcher.subsystem_subscriptions.intersection(
+        context.dispatcher.subsystem_events
+    )
     if not active:
         context.session.prevent_timeout = True
         return None
 
     response = []
-    context.events = set()
-    context.subscriptions = set()
+    context.dispatcher.subsystem_events = set()
+    context.dispatcher.subsystem_subscriptions = set()
 
     for subsystem in active:
         response.append(f"changed: {subsystem}")
@@ -120,10 +122,10 @@ def idle(context: MpdContext, *args: str) -> protocol.Result:
 @protocol.commands.add("noidle", list_command=False)
 def noidle(context: MpdContext) -> None:
     """See :meth:`_status_idle`."""
-    if not context.subscriptions:
+    if not context.dispatcher.subsystem_subscriptions:
         return
-    context.subscriptions = set()
-    context.events = set()
+    context.dispatcher.subsystem_subscriptions = set()
+    context.dispatcher.subsystem_events = set()
     context.session.prevent_timeout = False
 
 

--- a/src/mopidy_mpd/protocol/status.py
+++ b/src/mopidy_mpd/protocol/status.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Never
+from typing import TYPE_CHECKING
 
 from mopidy.core import PlaybackState
 
@@ -27,7 +27,7 @@ SUBSYSTEMS = [
 
 
 @protocol.commands.add("clearerror")
-def clearerror(context: MpdContext) -> Never:
+def clearerror(context: MpdContext) -> protocol.Result:
     """
     *musicpd.org, status section:*
 

--- a/src/mopidy_mpd/protocol/status.py
+++ b/src/mopidy_mpd/protocol/status.py
@@ -63,7 +63,7 @@ def currentsong(context: MpdContext) -> protocol.Result:
 
 
 @protocol.commands.add("idle")
-def idle(context: MpdContext, *subsystems: list[str]) -> protocol.Result:
+def idle(context: MpdContext, *args: str) -> protocol.Result:
     """
     *musicpd.org, status section:*
 
@@ -98,8 +98,7 @@ def idle(context: MpdContext, *subsystems: list[str]) -> protocol.Result:
     """
     # TODO: test against valid subsystems
 
-    if not subsystems:
-        subsystems = SUBSYSTEMS
+    subsystems = list(args) if args else SUBSYSTEMS
 
     for subsystem in subsystems:
         context.subscriptions.add(subsystem)

--- a/src/mopidy_mpd/protocol/status.py
+++ b/src/mopidy_mpd/protocol/status.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from mopidy.models import Track
     from mopidy.types import DurationMs
 
-    from mopidy_mpd.dispatcher import MpdContext
+    from mopidy_mpd.context import MpdContext
 
 
 #: Subsystems that can be registered with idle command.

--- a/src/mopidy_mpd/protocol/stickers.py
+++ b/src/mopidy_mpd/protocol/stickers.py
@@ -7,7 +7,7 @@ from mopidy_mpd import exceptions, protocol
 if TYPE_CHECKING:
     from mopidy.types import Uri
 
-    from mopidy_mpd.dispatcher import MpdContext
+    from mopidy_mpd.context import MpdContext
 
 
 @protocol.commands.add("sticker", list_command=False)

--- a/src/mopidy_mpd/protocol/stickers.py
+++ b/src/mopidy_mpd/protocol/stickers.py
@@ -1,8 +1,24 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Never
+
 from mopidy_mpd import exceptions, protocol
+
+if TYPE_CHECKING:
+    from mopidy.types import Uri
+
+    from mopidy_mpd.dispatcher import MpdContext
 
 
 @protocol.commands.add("sticker", list_command=False)
-def sticker(context, action, field, uri, name=None, value=None):  # noqa: PLR0913
+def sticker(  # noqa: PLR0913
+    context: MpdContext,
+    action: str,
+    field: str,
+    uri: Uri,
+    name: str | None = None,
+    value: str | None = None,
+) -> Never:
     """
     *musicpd.org, sticker section:*
 

--- a/src/mopidy_mpd/protocol/stored_playlists.py
+++ b/src/mopidy_mpd/protocol/stored_playlists.py
@@ -234,7 +234,7 @@ def _create_playlist(context: MpdContext, name: str, tracks: Iterable[Track]) ->
             return  # Created and saved
         continue  # Failed to save using this backend
     # Can't use backend appropriate for passed URI schemes, use default one
-    default_scheme = context.dispatcher.config["mpd"]["default_playlist_scheme"]
+    default_scheme = context.config["mpd"]["default_playlist_scheme"]
     new_playlist = context.core.playlists.create(name, default_scheme).get()
     if new_playlist is None:
         # If even MPD's default backend can't save playlist, everything is lost

--- a/src/mopidy_mpd/protocol/stored_playlists.py
+++ b/src/mopidy_mpd/protocol/stored_playlists.py
@@ -43,7 +43,7 @@ def _get_playlist(
     context: MpdContext, name: str, *, must_exist: bool
 ) -> Playlist | None:
     playlist = None
-    uri = context.lookup_playlist_uri_from_name(name)
+    uri = context.uri_map.playlist_uri_from_name(name)
     if uri:
         playlist = context.core.playlists.lookup(uri).get()
     if must_exist and playlist is None:
@@ -125,7 +125,7 @@ def listplaylists(context: MpdContext) -> protocol.ResultList:
     for playlist_ref in context.core.playlists.as_list().get():
         if not playlist_ref.name:
             continue
-        name = context.lookup_playlist_name_from_uri(playlist_ref.uri)
+        name = context.uri_map.playlist_name_from_uri(playlist_ref.uri)
         if name is None:
             continue
         result.append(("playlist", name))
@@ -383,7 +383,7 @@ def rm(context: MpdContext, name: str) -> None:
         Removes the playlist ``NAME.m3u`` from the playlist directory.
     """
     _check_playlist_name(name)
-    uri = context.lookup_playlist_uri_from_name(name)
+    uri = context.uri_map.playlist_uri_from_name(name)
     if not uri:
         raise exceptions.MpdNoExistError("No such playlist")
     context.core.playlists.delete(uri).get()

--- a/src/mopidy_mpd/protocol/stored_playlists.py
+++ b/src/mopidy_mpd/protocol/stored_playlists.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import datetime
 import logging
 import re
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Literal, cast, overload
 from urllib.parse import urlparse
 
+from mopidy.models import Track
 from mopidy.types import Uri, UriScheme
 
 from mopidy_mpd import exceptions, protocol, translator
@@ -13,7 +14,7 @@ from mopidy_mpd import exceptions, protocol, translator
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from mopidy.models import Playlist, Track
+    from mopidy.models import Playlist
 
     from mopidy_mpd.context import MpdContext
 
@@ -178,7 +179,11 @@ def load(
       in either or both ends.
     """
     playlist = _get_playlist(context, name, must_exist=True)
-    track_uris = [track.uri for track in playlist.tracks[playlist_slice]]
+    tracks = cast(  # TODO(type): Improve typing of models to avoid cast.
+        tuple[Track],
+        playlist.tracks[playlist_slice],  # pyright: ignore[reportIndexIssue]
+    )
+    track_uris = [track.uri for track in tracks]
     context.core.tracklist.add(uris=track_uris).get()
 
 

--- a/src/mopidy_mpd/protocol/stored_playlists.py
+++ b/src/mopidy_mpd/protocol/stored_playlists.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
     from mopidy.models import Playlist, Track
 
-    from mopidy_mpd.dispatcher import MpdContext
+    from mopidy_mpd.context import MpdContext
 
 logger = logging.getLogger(__name__)
 

--- a/src/mopidy_mpd/session.py
+++ b/src/mopidy_mpd/session.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, NoReturn, TypedDict
 
-from mopidy_mpd import dispatcher, formatting, network, protocol
+from mopidy_mpd import dispatcher, formatting, network, protocol, types
 from mopidy_mpd.protocol import tagtype_list
 
 if TYPE_CHECKING:
-    from mopidy.config import Config
     from mopidy.core import CoreProxy
 
     from mopidy_mpd.uri_mapper import MpdUriMapper
@@ -17,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class MpdSessionKwargs(TypedDict):
-    config: Config
+    config: types.Config
     core: CoreProxy
     uri_map: MpdUriMapper
     connection: network.Connection
@@ -35,7 +34,7 @@ class MpdSession(network.LineProtocol):
     def __init__(
         self,
         *,
-        config: Config,
+        config: types.Config,
         core: CoreProxy,
         uri_map: MpdUriMapper,
         connection: network.Connection,

--- a/src/mopidy_mpd/session.py
+++ b/src/mopidy_mpd/session.py
@@ -10,7 +10,6 @@ if TYPE_CHECKING:
     from mopidy.core import CoreProxy
     from mopidy.ext import Config
 
-    from mopidy_mpd.uri_mapper import MpdUriMapper
 
 logger = logging.getLogger(__name__)
 
@@ -26,17 +25,15 @@ class MpdSession(network.LineProtocol):
 
     def __init__(
         self,
+        config: Config,
+        core: CoreProxy,
         connection: network.Connection,
-        config: Config | None = None,
-        core: CoreProxy | None = None,
-        uri_map: MpdUriMapper | None = None,
     ) -> None:
         super().__init__(connection)
         self.dispatcher = dispatcher.MpdDispatcher(
             session=self,
             config=config,
             core=core,
-            uri_map=uri_map,
         )
         self.tagtypes = tagtype_list.TAGTYPE_LIST.copy()
 

--- a/src/mopidy_mpd/session.py
+++ b/src/mopidy_mpd/session.py
@@ -1,13 +1,21 @@
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING, NoReturn
 
 from mopidy_mpd import dispatcher, formatting, network, protocol
 from mopidy_mpd.protocol import tagtype_list
+
+if TYPE_CHECKING:
+    from mopidy.core import CoreProxy
+    from mopidy.ext import Config
+
+    from mopidy_mpd.uri_mapper import MpdUriMapper
 
 logger = logging.getLogger(__name__)
 
 
 class MpdSession(network.LineProtocol):
-
     """
     The MPD client session. Keeps track of a single client session. Any
     requests from the client is passed on to the MPD request dispatcher.
@@ -15,20 +23,28 @@ class MpdSession(network.LineProtocol):
 
     terminator = protocol.LINE_TERMINATOR
     encoding = protocol.ENCODING
-    delimiter = rb"\r?\n"
 
-    def __init__(self, connection, config=None, core=None, uri_map=None):
+    def __init__(
+        self,
+        connection: network.Connection,
+        config: Config | None = None,
+        core: CoreProxy | None = None,
+        uri_map: MpdUriMapper | None = None,
+    ) -> None:
         super().__init__(connection)
         self.dispatcher = dispatcher.MpdDispatcher(
-            session=self, config=config, core=core, uri_map=uri_map
+            session=self,
+            config=config,
+            core=core,
+            uri_map=uri_map,
         )
         self.tagtypes = tagtype_list.TAGTYPE_LIST.copy()
 
-    def on_start(self):
+    def on_start(self) -> None:
         logger.info("New MPD connection from %s", self.connection)
         self.send_lines([f"OK MPD {protocol.VERSION}"])
 
-    def on_line_received(self, line):
+    def on_line_received(self, line: str) -> None:
         logger.debug("Request from %s: %s", self.connection, line)
 
         # All mpd commands start with a lowercase alphabetic character
@@ -50,10 +66,10 @@ class MpdSession(network.LineProtocol):
 
         self.send_lines(response)
 
-    def on_event(self, subsystem):
+    def on_event(self, subsystem: str) -> None:
         self.dispatcher.handle_idle(subsystem)
 
-    def decode(self, line):
+    def decode(self, line: bytes) -> str:
         try:
             return super().decode(line)
         except ValueError:
@@ -62,6 +78,7 @@ class MpdSession(network.LineProtocol):
                 "supplied by client was not valid."
             )
             self.stop()
+            return NoReturn
 
-    def close(self):
+    def close(self) -> None:
         self.stop()

--- a/src/mopidy_mpd/session.py
+++ b/src/mopidy_mpd/session.py
@@ -1,17 +1,26 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, NoReturn
+from typing import TYPE_CHECKING, NoReturn, TypedDict
 
 from mopidy_mpd import dispatcher, formatting, network, protocol
 from mopidy_mpd.protocol import tagtype_list
 
 if TYPE_CHECKING:
+    from mopidy.config import Config
     from mopidy.core import CoreProxy
-    from mopidy.ext import Config
+
+    from mopidy_mpd.uri_mapper import MpdUriMapper
 
 
 logger = logging.getLogger(__name__)
+
+
+class MpdSessionKwargs(TypedDict):
+    config: Config
+    core: CoreProxy
+    uri_map: MpdUriMapper
+    connection: network.Connection
 
 
 class MpdSession(network.LineProtocol):
@@ -25,14 +34,17 @@ class MpdSession(network.LineProtocol):
 
     def __init__(
         self,
+        *,
         config: Config,
         core: CoreProxy,
+        uri_map: MpdUriMapper,
         connection: network.Connection,
     ) -> None:
         super().__init__(connection)
         self.dispatcher = dispatcher.MpdDispatcher(
             config=config,
             core=core,
+            uri_map=uri_map,
             session=self,
         )
         self.tagtypes = tagtype_list.TAGTYPE_LIST.copy()

--- a/src/mopidy_mpd/session.py
+++ b/src/mopidy_mpd/session.py
@@ -31,9 +31,9 @@ class MpdSession(network.LineProtocol):
     ) -> None:
         super().__init__(connection)
         self.dispatcher = dispatcher.MpdDispatcher(
-            session=self,
             config=config,
             core=core,
+            session=self,
         )
         self.tagtypes = tagtype_list.TAGTYPE_LIST.copy()
 

--- a/src/mopidy_mpd/tokenize.py
+++ b/src/mopidy_mpd/tokenize.py
@@ -44,7 +44,7 @@ BAD_QUOTED_PARAM_RE = re.compile(
 UNESCAPE_RE = re.compile(r"\\(.)")  # Backslash escapes any following char.
 
 
-def split(line):
+def split(line: str) -> list[str]:
     """Splits a line into tokens using same rules as MPD.
 
     - Lines may not start with whitespace
@@ -71,7 +71,7 @@ def split(line):
     if whitespace:
         raise exceptions.MpdUnknownError("Letter expected")
 
-    result = [command]
+    result: list[str] = [command]
     while remainder:
         match = PARAM_RE.match(remainder)
         if not match:
@@ -82,7 +82,7 @@ def split(line):
     return result
 
 
-def _determine_error_message(remainder):
+def _determine_error_message(remainder: str) -> str:
     """Helper to emulate MPD errors."""
     # Following checks are simply to match MPD error messages:
     match = BAD_QUOTED_PARAM_RE.match(remainder)

--- a/src/mopidy_mpd/translator.py
+++ b/src/mopidy_mpd/translator.py
@@ -26,7 +26,8 @@ def track_to_mpd_format(  # noqa: C901, PLR0912
     """
     Format track for output to MPD client.
 
-    :param track: the track
+    :param obj: the track
+    :param tagtypes: the MPD tagtypes enabled by the client
     :param position: track's position in playlist
     :param stream_title: the current streams title
     """
@@ -120,7 +121,7 @@ def _has_value(
     Determine whether to add the tagtype to the output or not. The tagtype must
     be in the list of tagtypes configured for the client.
 
-    :param tagtypes: the MPD tagtypes configured for the client
+    :param tagtypes: the MPD tagtypes enabled by the client
     :param tagtype: the MPD tagtype
     :param value: the tag value
     """
@@ -183,8 +184,10 @@ def tracks_to_mpd_format(
     Optionally limit output to the slice ``[start:end]`` of the list.
 
     :param tracks: the tracks
+    :param tagtypes: the MPD tagtypes enabled by the client
     :param start: position of first track to include in output
-    :param end: position after last track to include in output
+    :param end: position after last track to include in output, or ``None`` for
+      end of list
     """
     if end is None:
         end = len(tracks)
@@ -210,6 +213,7 @@ def playlist_to_mpd_format(
     Format playlist for output to MPD client.
 
     :param playlist: the playlist
+    :param tagtypes: the MPD tagtypes enabled by the client
     :param start: position of first track to include in output
     :param end: position after last track to include in output
     """

--- a/src/mopidy_mpd/translator.py
+++ b/src/mopidy_mpd/translator.py
@@ -1,35 +1,47 @@
+from __future__ import annotations
+
 import datetime
 import logging
+from typing import TYPE_CHECKING
 
-from mopidy.models import TlTrack
+from mopidy.models import Album, Artist, Playlist, TlTrack, Track
 
 from mopidy_mpd.protocol import tagtype_list
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from mopidy_mpd import protocol
 
 logger = logging.getLogger(__name__)
 
 
-def track_to_mpd_format(track, tagtypes, *, position=None, stream_title=None):  # noqa: C901, PLR0912
+def track_to_mpd_format(  # noqa: C901, PLR0912
+    obj: Track | TlTrack,
+    tagtypes: set[str],
+    *,
+    position: int | None = None,
+    stream_title: str | None = None,
+) -> protocol.ResultList:
     """
     Format track for output to MPD client.
 
     :param track: the track
-    :type track: :class:`mopidy.models.Track` or :class:`mopidy.models.TlTrack`
     :param position: track's position in playlist
-    :type position: integer
     :param stream_title: the current streams title
-    :type position: string
-    :rtype: list of two-tuples
     """
-    if isinstance(track, TlTrack):
-        (tlid, track) = track
-    else:
-        (tlid, track) = (None, track)  # noqa: PLW0127
+    match obj:
+        case TlTrack() as tl_track:
+            tlid = tl_track.tlid
+            track = tl_track.track
+        case Track() as track:
+            tlid = None
 
     if not track.uri:
         logger.warning("Ignoring track without uri")
         return []
 
-    result = [
+    result: protocol.Result = [
         ("file", track.uri),
         ("Time", track.length and (track.length // 1000) or 0),
         *multi_tag_list(track.artists, "name", "Artist"),
@@ -95,17 +107,18 @@ def track_to_mpd_format(track, tagtypes, *, position=None, stream_title=None):  
     return [element for element in result if _has_value(tagtypes, *element)]
 
 
-def _has_value(tagtypes, tagtype, value):
+def _has_value(
+    tagtypes: set[str],
+    tagtype: str,
+    value: str | int,
+) -> bool:
     """
     Determine whether to add the tagtype to the output or not. The tagtype must
     be in the list of tagtypes configured for the client.
 
     :param tagtypes: the MPD tagtypes configured for the client
-    :type tagtypes: set of strings
     :param tagtype: the MPD tagtype
-    :type tagtype: string
     :param value: the tag value
-    :rtype: bool
     """
     if tagtype in tagtype_list.TAGTYPE_LIST:
         if tagtype not in tagtypes:
@@ -114,16 +127,15 @@ def _has_value(tagtypes, tagtype, value):
     return True
 
 
-def concat_multi_values(models, attribute):
+def concat_multi_values(
+    models: Iterable[Artist | Album | Track],
+    attribute: str,
+) -> str:
     """
     Format Mopidy model values for output to MPD client.
 
     :param models: the models
-    :type models: array of :class:`mopidy.models.Artist`,
-        :class:`mopidy.models.Album` or :class:`mopidy.models.Track`
     :param attribute: the attribute to use
-    :type attribute: string
-    :rtype: string
     """
     # Don't sort the values. MPD doesn't appear to (or if it does it's not
     # strict alphabetical). If we just use them in the order in which they come
@@ -133,60 +145,68 @@ def concat_multi_values(models, attribute):
     )
 
 
-def multi_tag_list(objects, attribute, tag):
+def multi_tag_list(
+    models: Iterable[Artist | Album | Track],
+    attribute: str,
+    tag: str,
+) -> protocol.ResultList:
     """
     Format multiple objects for output to MPD client in a list with one tag per
     value.
 
-    :param objects: the model objects
-    :type objects: array of :class:`mopidy.models.Artist`,
-        :class:`mopidy.models.Album`, or :class:`mopidy.models.Track`
+    :param models: the model objects
     :param attribute: the attribute to use
-    :type attribute: string
     :param tag: the name of the tag
-    :type tag: string
-    :rtype: list of tuples of string and attribute value
     """
 
     return [
         (tag, getattr(obj, attribute))
-        for obj in objects
+        for obj in models
         if getattr(obj, attribute, None) is not None
     ]
 
 
-def tracks_to_mpd_format(tracks, tagtypes, *, start=0, end=None):
+def tracks_to_mpd_format(
+    tracks: Sequence[Track | TlTrack],
+    tagtypes: set[str],
+    *,
+    start: int = 0,
+    end: int | None = None,
+) -> protocol.ResultList:
     """
     Format list of tracks for output to MPD client.
 
     Optionally limit output to the slice ``[start:end]`` of the list.
 
     :param tracks: the tracks
-    :type tracks: list of :class:`mopidy.models.Track` or
-        :class:`mopidy.models.TlTrack`
     :param start: position of first track to include in output
-    :type start: int (positive or negative)
     :param end: position after last track to include in output
-    :type end: int (positive or negative) or :class:`None` for end of list
-    :rtype: list of lists of two-tuples
     """
     if end is None:
         end = len(tracks)
     tracks = tracks[start:end]
     positions = range(start, end)
     assert len(tracks) == len(positions)
-    result = []
-    for track, position in zip(tracks, positions, strict=False):
+    result: protocol.ResultList = []
+    for track, position in zip(tracks, positions, strict=True):
         formatted_track = track_to_mpd_format(track, tagtypes, position=position)
         if formatted_track:
-            result.append(formatted_track)
+            result.extend(formatted_track)
     return result
 
 
-def playlist_to_mpd_format(playlist, tagtypes, *, start=0, end=None):
+def playlist_to_mpd_format(
+    playlist: Playlist,
+    tagtypes: set[str],
+    *,
+    start: int = 0,
+    end: int | None = None,
+) -> protocol.ResultList:
     """
     Format playlist for output to MPD client.
 
-    Arguments as for :func:`tracks_to_mpd_format`, except the first one.
+    :param playlist: the playlist
+    :param start: position of first track to include in output
+    :param end: position after last track to include in output
     """
-    return tracks_to_mpd_format(playlist.tracks, tagtypes, start=start, end=end)
+    return tracks_to_mpd_format(list(playlist.tracks), tagtypes, start=start, end=end)

--- a/src/mopidy_mpd/types.py
+++ b/src/mopidy_mpd/types.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import TypeAlias, TypedDict
+
+
+class MpdConfig(TypedDict):
+    hostname: str
+    port: int
+    password: str | None
+    max_connections: int
+    connection_timeout: int
+    zeroconf: str
+    command_blacklist: list[str]
+    default_playlist_scheme: str
+
+
+SocketAddress: TypeAlias = tuple[str, int | None]

--- a/src/mopidy_mpd/types.py
+++ b/src/mopidy_mpd/types.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
-from typing import TypeAlias, TypedDict
+from typing import TYPE_CHECKING, TypeAlias, TypedDict
+
+from mopidy.config import Config as MopidyConfig
+
+if TYPE_CHECKING:
+    from mopidy.types import UriScheme
+
+
+class Config(MopidyConfig):
+    mpd: MpdConfig
 
 
 class MpdConfig(TypedDict):
@@ -11,7 +20,7 @@ class MpdConfig(TypedDict):
     connection_timeout: int
     zeroconf: str
     command_blacklist: list[str]
-    default_playlist_scheme: str
+    default_playlist_scheme: UriScheme
 
 
 SocketAddress: TypeAlias = tuple[str, int | None]

--- a/src/mopidy_mpd/uri_mapper.py
+++ b/src/mopidy_mpd/uri_mapper.py
@@ -1,28 +1,34 @@
-import re
+from __future__ import annotations
 
-# TOOD: refactor this into a generic mapper that does not know about browse
-# or playlists and then use one instance for each case?
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mopidy.core import CoreProxy
+    from mopidy.types import Uri
 
 
 class MpdUriMapper:
-
     """
     Maintains the mappings between uniquified MPD names and URIs.
     """
 
-    #: The Mopidy core API. An instance of :class:`mopidy.core.Core`.
-    core = None
+    # TODO: refactor this into a generic mapper that does not know about browse
+    # or playlists and then use one instance for each case?
+
+    #: The Mopidy core API.
+    core: CoreProxy
 
     _invalid_browse_chars = re.compile(r"[\n\r]")
     _invalid_playlist_chars = re.compile(r"[/]")
 
-    def __init__(self, core=None):
+    def __init__(self, core: CoreProxy) -> None:
         self.core = core
-        self._uri_from_name = {}
-        self._browse_name_from_uri = {}
-        self._playlist_name_from_uri = {}
+        self._uri_from_name: dict[str, Uri | None] = {}
+        self._browse_name_from_uri: dict[Uri | None, str] = {}
+        self._playlist_name_from_uri: dict[Uri | None, str] = {}
 
-    def _create_unique_name(self, name, uri):
+    def _create_unique_name(self, name: str, uri: Uri | None) -> str:
         stripped_name = self._invalid_browse_chars.sub(" ", name)
         name = stripped_name
         i = 2
@@ -33,7 +39,7 @@ class MpdUriMapper:
             i += 1
         return name
 
-    def insert(self, name, uri, *, playlist=False):
+    def insert(self, name: str, uri: Uri | None, *, playlist: bool = False) -> str:
         """
         Create a unique and MPD compatible name that maps to the given URI.
         """
@@ -45,13 +51,13 @@ class MpdUriMapper:
             self._browse_name_from_uri[uri] = name
         return name
 
-    def uri_from_name(self, name):
+    def uri_from_name(self, name: str) -> Uri | None:
         """
-        Return the uri for the given MPD name.
+        Return the URI for the given MPD name.
         """
         return self._uri_from_name.get(name)
 
-    def refresh_playlists_mapping(self):
+    def refresh_playlists_mapping(self) -> None:
         """
         Maintain map between playlists and unique playlist names to be used by
         MPD.
@@ -65,7 +71,7 @@ class MpdUriMapper:
             name = self._invalid_playlist_chars.sub("|", playlist_ref.name)
             self.insert(name, playlist_ref.uri, playlist=True)
 
-    def playlist_uri_from_name(self, name):
+    def playlist_uri_from_name(self, name: str) -> Uri | None:
         """
         Helper function to retrieve a playlist URI from its unique MPD name.
         """
@@ -73,7 +79,7 @@ class MpdUriMapper:
             self.refresh_playlists_mapping()
         return self._uri_from_name.get(name)
 
-    def playlist_name_from_uri(self, uri):
+    def playlist_name_from_uri(self, uri: Uri) -> str:
         """
         Helper function to retrieve the unique MPD playlist name from its URI.
         """

--- a/tests/network/test_connection.py
+++ b/tests/network/test_connection.py
@@ -326,20 +326,12 @@ class ConnectionTest(unittest.TestCase):
         network.Connection.enable_timeout(self.mock)
         assert GLib.timeout_add_seconds.call_count == 0
 
-        self.mock.timeout = None
-        network.Connection.enable_timeout(self.mock)
-        assert GLib.timeout_add_seconds.call_count == 0
-
     def test_enable_timeout_does_not_call_disable_for_invalid_timeout(self):
         self.mock.timeout = 0
         network.Connection.enable_timeout(self.mock)
         assert self.mock.disable_timeout.call_count == 0
 
         self.mock.timeout = -1
-        network.Connection.enable_timeout(self.mock)
-        assert self.mock.disable_timeout.call_count == 0
-
-        self.mock.timeout = None
         network.Connection.enable_timeout(self.mock)
         assert self.mock.disable_timeout.call_count == 0
 

--- a/tests/network/test_connection.py
+++ b/tests/network/test_connection.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, call, patch, sentinel
 
 import pykka
 from gi.repository import GLib
-from mopidy_mpd import network
+from mopidy_mpd import network, uri_mapper
 
 from tests import any_int, any_unicode
 
@@ -20,11 +20,13 @@ class ConnectionTest(unittest.TestCase):
 
         network.Connection.__init__(
             self.mock,
-            Mock(),
-            {},
-            sock,
-            (sentinel.host, sentinel.port),
-            sentinel.timeout,
+            config={},
+            core=Mock(),
+            uri_map=Mock(spec=uri_mapper.MpdUriMapper),
+            protocol=Mock(spec=network.LineProtocol),
+            sock=sock,
+            addr=(sentinel.host, sentinel.port),
+            timeout=sentinel.timeout,
         )
         sock.setblocking.assert_called_once_with(False)
 
@@ -33,22 +35,26 @@ class ConnectionTest(unittest.TestCase):
 
         network.Connection.__init__(
             self.mock,
-            protocol,
-            {},
-            Mock(),
-            (sentinel.host, sentinel.port),
-            sentinel.timeout,
+            config={},
+            core=Mock(),
+            uri_map=Mock(spec=uri_mapper.MpdUriMapper),
+            protocol=protocol,
+            sock=Mock(spec=socket.SocketType),
+            addr=(sentinel.host, sentinel.port),
+            timeout=sentinel.timeout,
         )
-        protocol.start.assert_called_once_with(self.mock)
+        protocol.start.assert_called_once()
 
     def test_init_enables_recv_and_timeout(self):
         network.Connection.__init__(
             self.mock,
-            Mock(),
-            {},
-            Mock(),
-            (sentinel.host, sentinel.port),
-            sentinel.timeout,
+            config={},
+            core=Mock(),
+            uri_map=Mock(spec=uri_mapper.MpdUriMapper),
+            protocol=Mock(spec=network.LineProtocol),
+            sock=Mock(spec=socket.SocketType),
+            addr=(sentinel.host, sentinel.port),
+            timeout=sentinel.timeout,
         )
         self.mock.enable_recv.assert_called_once_with()
         self.mock.enable_timeout.assert_called_once_with()
@@ -56,15 +62,20 @@ class ConnectionTest(unittest.TestCase):
     def test_init_stores_values_in_attributes(self):
         addr = (sentinel.host, sentinel.port)
         protocol = Mock(spec=network.LineProtocol)
-        protocol_kwargs = {}
         sock = Mock(spec=socket.SocketType)
 
         network.Connection.__init__(
-            self.mock, protocol, protocol_kwargs, sock, addr, sentinel.timeout
+            self.mock,
+            config={},
+            core=Mock(),
+            uri_map=Mock(spec=uri_mapper.MpdUriMapper),
+            protocol=protocol,
+            sock=sock,
+            addr=addr,
+            timeout=sentinel.timeout,
         )
         assert sock == self.mock._sock
         assert protocol == self.mock.protocol
-        assert protocol_kwargs == self.mock.protocol_kwargs
         assert sentinel.timeout == self.mock.timeout
         assert sentinel.host == self.mock.host
         assert sentinel.port == self.mock.port
@@ -77,11 +88,17 @@ class ConnectionTest(unittest.TestCase):
             sentinel.scopeid,
         )
         protocol = Mock(spec=network.LineProtocol)
-        protocol_kwargs = {}
         sock = Mock(spec=socket.SocketType)
 
         network.Connection.__init__(
-            self.mock, protocol, protocol_kwargs, sock, addr, sentinel.timeout
+            self.mock,
+            config={},
+            core=Mock(),
+            uri_map=Mock(spec=uri_mapper.MpdUriMapper),
+            protocol=protocol,
+            sock=sock,
+            addr=addr,
+            timeout=sentinel.timeout,
         )
         assert sentinel.host == self.mock.host
         assert sentinel.port == self.mock.port

--- a/tests/network/test_lineprotocol.py
+++ b/tests/network/test_lineprotocol.py
@@ -22,19 +22,10 @@ class LineProtocolTest(unittest.TestCase):
         self.mock.parse_lines.return_value = return_value or []
 
     def test_init_stores_values_in_attributes(self):
-        delimiter = re.compile(network.LineProtocol.terminator)
         network.LineProtocol.__init__(self.mock, sentinel.connection)
         assert sentinel.connection == self.mock.connection
         assert self.mock.recv_buffer == b""
-        assert delimiter == self.mock.delimiter
         assert not self.mock.prevent_timeout
-
-    def test_init_compiles_delimiter(self):
-        self.mock.delimiter = "\r?\n"
-        delimiter = re.compile("\r?\n")
-
-        network.LineProtocol.__init__(self.mock, sentinel.connection)
-        assert delimiter == self.mock.delimiter
 
     def test_on_receive_close_calls_stop(self):
         self.prepare_on_receive_test()

--- a/tests/network/test_server.py
+++ b/tests/network/test_server.py
@@ -204,12 +204,15 @@ class ServerTest(unittest.TestCase):
     def test_accept_connection(self):
         sock = Mock(spec=socket.socket)
         connected_sock = Mock(spec=socket.socket)
-        sock.accept.return_value = (connected_sock, sentinel.addr)
+        sock.accept.return_value = (
+            connected_sock,
+            (sentinel.host, sentinel.port, sentinel.flow, sentinel.scope),
+        )
         self.mock.server_socket = sock
 
         sock, addr = network.Server.accept_connection(self.mock)
-        assert connected_sock == sock
-        assert sentinel.addr == addr
+        assert sock == connected_sock
+        assert addr == (sentinel.host, sentinel.port)
 
     def test_accept_connection_unix(self):
         sock = Mock(spec=socket.socket)

--- a/tests/network/test_server.py
+++ b/tests/network/test_server.py
@@ -5,7 +5,8 @@ import unittest
 from unittest.mock import Mock, patch, sentinel
 
 from gi.repository import GLib
-from mopidy_mpd import network
+from mopidy.core import CoreProxy
+from mopidy_mpd import network, uri_mapper
 
 from tests import any_int
 
@@ -17,7 +18,13 @@ class ServerTest(unittest.TestCase):
     @patch.object(network, "get_socket_address", new=Mock())
     def test_init_calls_create_server_socket(self):
         network.Server.__init__(
-            self.mock, sentinel.host, sentinel.port, sentinel.protocol
+            self.mock,
+            config={},
+            core=Mock(spec=CoreProxy),
+            uri_map=Mock(uri_mapper.MpdUriMapper),
+            protocol=sentinel.protocol,
+            host=sentinel.host,
+            port=sentinel.port,
         )
         self.mock.create_server_socket.assert_called_once_with(
             sentinel.host, sentinel.port
@@ -27,7 +34,13 @@ class ServerTest(unittest.TestCase):
     @patch.object(network, "get_socket_address", new=Mock())
     def test_init_calls_get_socket_address(self):
         network.Server.__init__(
-            self.mock, sentinel.host, sentinel.port, sentinel.protocol
+            self.mock,
+            config={},
+            core=Mock(spec=CoreProxy),
+            uri_map=Mock(uri_mapper.MpdUriMapper),
+            protocol=sentinel.protocol,
+            host=sentinel.host,
+            port=sentinel.port,
         )
         self.mock.create_server_socket.return_value = None
         network.get_socket_address.assert_called_once_with(sentinel.host, sentinel.port)
@@ -40,7 +53,13 @@ class ServerTest(unittest.TestCase):
         self.mock.create_server_socket.return_value = sock
 
         network.Server.__init__(
-            self.mock, sentinel.host, sentinel.port, sentinel.protocol
+            self.mock,
+            config={},
+            core=Mock(spec=CoreProxy),
+            uri_map=Mock(uri_mapper.MpdUriMapper),
+            protocol=sentinel.protocol,
+            host=sentinel.host,
+            port=sentinel.port,
         )
         self.mock.register_server_socket.assert_called_once_with(sentinel.fileno)
 
@@ -52,7 +71,13 @@ class ServerTest(unittest.TestCase):
 
         with self.assertRaises(socket.error):
             network.Server.__init__(
-                self.mock, sentinel.host, sentinel.port, sentinel.protocol
+                self.mock,
+                config={},
+                core=Mock(spec=CoreProxy),
+                uri_map=Mock(uri_mapper.MpdUriMapper),
+                protocol=sentinel.protocol,
+                host=sentinel.host,
+                port=sentinel.port,
             )
 
     def test_init_stores_values_in_attributes(self):
@@ -62,9 +87,12 @@ class ServerTest(unittest.TestCase):
 
         network.Server.__init__(
             self.mock,
-            str(sentinel.host),
-            sentinel.port,
-            sentinel.protocol,
+            config={},
+            core=Mock(spec=CoreProxy),
+            uri_map=Mock(uri_mapper.MpdUriMapper),
+            protocol=sentinel.protocol,
+            host=str(sentinel.host),
+            port=sentinel.port,
             max_connections=sentinel.max_connections,
             timeout=sentinel.timeout,
         )
@@ -264,21 +292,6 @@ class ServerTest(unittest.TestCase):
 
         get_by_class.return_value = []
         assert network.Server.number_of_connections(self.mock) == 0
-
-    @patch.object(network, "Connection", new=Mock())
-    def test_init_connection(self):
-        self.mock.protocol = sentinel.protocol
-        self.mock.protocol_kwargs = {}
-        self.mock.timeout = sentinel.timeout
-
-        network.Server.init_connection(self.mock, sentinel.sock, sentinel.addr)
-        network.Connection.assert_called_once_with(
-            sentinel.protocol,
-            {},
-            sentinel.sock,
-            sentinel.addr,
-            sentinel.timeout,
-        )
 
     def test_reject_connection(self):
         sock = Mock(spec=socket.socket)

--- a/tests/protocol/__init__.py
+++ b/tests/protocol/__init__.py
@@ -1,9 +1,10 @@
 import unittest
+from typing import cast
 from unittest import mock
 
 import pykka
 from mopidy import core
-from mopidy_mpd import session, uri_mapper
+from mopidy_mpd import session
 
 from tests import dummy_audio, dummy_backend, dummy_mixer
 
@@ -38,20 +39,21 @@ class BaseTestCase(unittest.TestCase):
         self.audio = dummy_audio.create_proxy()
         self.backend = dummy_backend.create_proxy(audio=self.audio)
 
-        self.core = core.Core.start(
-            self.get_config(),
-            audio=self.audio,
-            mixer=self.mixer,
-            backends=[self.backend],
-        ).proxy()
+        self.core = cast(
+            core.CoreProxy,
+            core.Core.start(
+                self.get_config(),
+                audio=self.audio,
+                mixer=self.mixer,
+                backends=[self.backend],
+            ).proxy(),
+        )
 
-        self.uri_map = uri_mapper.MpdUriMapper(self.core)
         self.connection = MockConnection()
         self.session = session.MpdSession(
-            self.connection,
             config=self.get_config(),
             core=self.core,
-            uri_map=self.uri_map,
+            connection=self.connection,
         )
         self.dispatcher = self.session.dispatcher
         self.context = self.dispatcher.context

--- a/tests/protocol/__init__.py
+++ b/tests/protocol/__init__.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pykka
 from mopidy import core
-from mopidy_mpd import session
+from mopidy_mpd import session, uri_mapper
 
 from tests import dummy_audio, dummy_backend, dummy_mixer
 
@@ -28,7 +28,11 @@ class BaseTestCase(unittest.TestCase):
     def get_config(self):
         return {
             "core": {"max_tracklist_length": 10000},
-            "mpd": {"password": None, "default_playlist_scheme": "dummy"},
+            "mpd": {
+                "command_blacklist": [],
+                "default_playlist_scheme": "dummy",
+                "password": None,
+            },
         }
 
     def setUp(self):
@@ -53,6 +57,7 @@ class BaseTestCase(unittest.TestCase):
         self.session = session.MpdSession(
             config=self.get_config(),
             core=self.core,
+            uri_map=uri_mapper.MpdUriMapper(self.core),
             connection=self.connection,
         )
         self.dispatcher = self.session.dispatcher

--- a/tests/protocol/test_idle.py
+++ b/tests/protocol/test_idle.py
@@ -10,10 +10,10 @@ class IdleHandlerTest(protocol.BaseTestCase):
         self.session.on_event(subsystem)
 
     def assertEqualEvents(self, events):  # noqa: N802
-        assert set(events) == self.context.events
+        assert self.dispatcher.subsystem_events == set(events)
 
     def assertEqualSubscriptions(self, events):  # noqa: N802
-        assert set(events) == self.context.subscriptions
+        assert self.dispatcher.subsystem_subscriptions == set(events)
 
     def assertNoEvents(self):  # noqa: N802
         self.assertEqualEvents([])

--- a/tests/protocol/test_music_db.py
+++ b/tests/protocol/test_music_db.py
@@ -9,24 +9,17 @@ from tests import protocol
 # TODO: split into more modules for faster parallel tests?
 
 
-class QueryFromMpdSearchFormatTest(unittest.TestCase):
+class QueryForSearchTest(unittest.TestCase):
     def test_dates_are_extracted(self):
-        result = music_db._query_from_mpd_search_parameters(
-            ["Date", "1974-01-02", "Date", "1975"], music_db._SEARCH_MAPPING
-        )
-        assert result["date"][0] == "1974-01-02"
-        assert result["date"][1] == "1975"
+        result = music_db._query_for_search(["Date", "1974-01-02", "Date", "1975"])
+        assert result["date"] == ["1974-01-02", "1975"]
 
     def test_empty_value_is_ignored(self):
-        result = music_db._query_from_mpd_search_parameters(
-            ["Date", ""], music_db._SEARCH_MAPPING
-        )
+        result = music_db._query_for_search(["Date", ""])
         assert result == {}
 
     def test_whitespace_value_is_ignored(self):
-        result = music_db._query_from_mpd_search_parameters(
-            ["Date", "  "], music_db._SEARCH_MAPPING
-        )
+        result = music_db._query_for_search(["Date", "  "])
         assert result == {}
 
     # TODO Test more mappings

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import unittest
+from typing import TYPE_CHECKING
 
 from mopidy_mpd import exceptions, protocol
-from mopidy_mpd.dispatcher import MpdContext
+
+if TYPE_CHECKING:
+    from mopidy_mpd.context import MpdContext
 
 
 class TestConverts(unittest.TestCase):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,6 +1,7 @@
 import unittest
 
 from mopidy_mpd import exceptions, protocol
+from mopidy_mpd.dispatcher import MpdContext
 
 
 class TestConverts(unittest.TestCase):
@@ -56,11 +57,11 @@ class TestCommands(unittest.TestCase):
 
     def test_add_as_a_decorator(self):
         @self.commands.add("test")
-        def test(context):
+        def test(context: MpdContext):
             pass
 
     def test_register_second_command_to_same_name_fails(self):
-        def func(context):
+        def func(context: MpdContext):
             pass
 
         self.commands.add("foo")(func)
@@ -70,40 +71,42 @@ class TestCommands(unittest.TestCase):
     def test_function_only_takes_context_succeeds(self):
         sentinel = object()
         self.commands.add("bar")(lambda context: sentinel)
-        assert sentinel == self.commands.call(["bar"])
+        assert sentinel == self.commands.call(context=None, tokens=["bar"])
 
     def test_function_has_required_arg_succeeds(self):
         sentinel = object()
         self.commands.add("bar")(lambda context, required: sentinel)
-        assert sentinel == self.commands.call(["bar", "arg"])
+        assert sentinel == self.commands.call(context=None, tokens=["bar", "arg"])
 
     def test_function_has_optional_args_succeeds(self):
         sentinel = object()
         self.commands.add("bar")(lambda context, optional=None: sentinel)
-        assert sentinel == self.commands.call(["bar"])
-        assert sentinel == self.commands.call(["bar", "arg"])
+        assert sentinel == self.commands.call(context=None, tokens=["bar"])
+        assert sentinel == self.commands.call(context=None, tokens=["bar", "arg"])
 
     def test_function_has_required_and_optional_args_succeeds(self):
         sentinel = object()
 
-        def func(context, required, optional=None):
+        def func(context: MpdContext, required, optional=None):
             return sentinel
 
         self.commands.add("bar")(func)
-        assert sentinel == self.commands.call(["bar", "arg"])
-        assert sentinel == self.commands.call(["bar", "arg", "arg"])
+        assert sentinel == self.commands.call(context=None, tokens=["bar", "arg"])
+        assert sentinel == self.commands.call(
+            context=None, tokens=["bar", "arg", "arg"]
+        )
 
     def test_function_has_varargs_succeeds(self):
         sentinel, args = object(), []
         self.commands.add("bar")(lambda context, *args: sentinel)
         for _ in range(10):
-            assert sentinel == self.commands.call(["bar", *args])
+            assert sentinel == self.commands.call(context=None, tokens=["bar", *args])
             args.append("test")
 
     def test_function_has_only_varags_succeeds(self):
         sentinel = object()
         self.commands.add("baz")(lambda *args: sentinel)
-        assert sentinel == self.commands.call(["baz"])
+        assert sentinel == self.commands.call(context=None, tokens=["baz"])
 
     def test_function_has_no_arguments_fails(self):
         with self.assertRaises(TypeError):
@@ -112,7 +115,7 @@ class TestCommands(unittest.TestCase):
     def test_function_has_required_and_varargs_fails(self):
         with self.assertRaises(TypeError):
 
-            def func(context, required, *args):
+            def func(context: MpdContext, required, *args):
                 pass
 
             self.commands.add("test")(func)
@@ -120,7 +123,7 @@ class TestCommands(unittest.TestCase):
     def test_function_has_optional_and_varargs_fails(self):
         with self.assertRaises(TypeError):
 
-            def func(context, optional=None, *args):
+            def func(context: MpdContext, optional=None, *args):
                 pass
 
             self.commands.add("test")(func)
@@ -135,40 +138,43 @@ class TestCommands(unittest.TestCase):
         self.commands.add("bar")(lambda context: sentinel2)
         self.commands.add("baz")(lambda context: sentinel3)
 
-        assert sentinel1 == self.commands.call(["foo"])
-        assert sentinel2 == self.commands.call(["bar"])
-        assert sentinel3 == self.commands.call(["baz"])
+        assert sentinel1 == self.commands.call(context=None, tokens=["foo"])
+        assert sentinel2 == self.commands.call(context=None, tokens=["bar"])
+        assert sentinel3 == self.commands.call(context=None, tokens=["baz"])
 
     def test_call_with_nonexistent_handler(self):
         with self.assertRaises(exceptions.MpdUnknownCommandError):
-            self.commands.call(["bar"])
+            self.commands.call(context=None, tokens=["bar"])
 
     def test_call_passes_context(self):
         sentinel = object()
         self.commands.add("foo")(lambda context: context)
-        assert sentinel == self.commands.call(["foo"], context=sentinel)
+        assert sentinel == self.commands.call(context=sentinel, tokens=["foo"])
 
     def test_call_without_args_fails(self):
         with self.assertRaises(exceptions.MpdNoCommandError):
-            self.commands.call([])
+            self.commands.call(context=None, tokens=[])
 
     def test_call_passes_required_argument(self):
         self.commands.add("foo")(lambda context, required: required)
-        assert self.commands.call(["foo", "test123"]) == "test123"
+        assert self.commands.call(context=None, tokens=["foo", "test123"]) == "test123"
 
     def test_call_passes_optional_argument(self):
         sentinel = object()
         self.commands.add("foo")(lambda context, optional=sentinel: optional)
-        assert sentinel == self.commands.call(["foo"])
-        assert self.commands.call(["foo", "test"]) == "test"
+        assert sentinel == self.commands.call(context=None, tokens=["foo"])
+        assert self.commands.call(context=None, tokens=["foo", "test"]) == "test"
 
     def test_call_passes_required_and_optional_argument(self):
-        def func(context, required, optional=None):
+        def func(context: MpdContext, required, optional=None):
             return (required, optional)
 
         self.commands.add("foo")(func)
-        assert self.commands.call(["foo", "arg"]) == ("arg", None)
-        assert self.commands.call(["foo", "arg", "kwarg"]) == ("arg", "kwarg")
+        assert self.commands.call(context=None, tokens=["foo", "arg"]) == ("arg", None)
+        assert self.commands.call(context=None, tokens=["foo", "arg", "kwarg"]) == (
+            "arg",
+            "kwarg",
+        )
 
     def test_call_passes_varargs(self):
         self.commands.add("foo")(lambda context, *args: args)
@@ -176,50 +182,50 @@ class TestCommands(unittest.TestCase):
     def test_call_incorrect_args(self):
         self.commands.add("foo")(lambda context: context)
         with self.assertRaises(exceptions.MpdArgError):
-            self.commands.call(["foo", "bar"])
+            self.commands.call(context=None, tokens=["foo", "bar"])
 
         self.commands.add("bar")(lambda context, required: context)
         with self.assertRaises(exceptions.MpdArgError):
-            self.commands.call(["bar", "bar", "baz"])
+            self.commands.call(context=None, tokens=["bar", "bar", "baz"])
 
         self.commands.add("baz")(lambda context, optional=None: context)
         with self.assertRaises(exceptions.MpdArgError):
-            self.commands.call(["baz", "bar", "baz"])
+            self.commands.call(context=None, tokens=["baz", "bar", "baz"])
 
     def test_validator_gets_applied_to_required_arg(self):
         sentinel = object()
 
-        def func(context, required):
+        def func(context: MpdContext, required):
             return required
 
         self.commands.add("test", required=lambda v: sentinel)(func)
-        assert sentinel == self.commands.call(["test", "foo"])
+        assert sentinel == self.commands.call(context=None, tokens=["test", "foo"])
 
     def test_validator_gets_applied_to_optional_arg(self):
         sentinel = object()
 
-        def func(context, optional=None):
+        def func(context: MpdContext, optional=None):
             return optional
 
         self.commands.add("foo", optional=lambda v: sentinel)(func)
 
-        assert sentinel == self.commands.call(["foo", "123"])
+        assert sentinel == self.commands.call(context=None, tokens=["foo", "123"])
 
     def test_validator_skips_optional_default(self):
         sentinel = object()
 
-        def func(context, optional=sentinel):
+        def func(context: MpdContext, optional=sentinel):
             return optional
 
         self.commands.add("foo", optional=lambda v: None)(func)
 
-        assert sentinel == self.commands.call(["foo"])
+        assert sentinel == self.commands.call(context=None, tokens=["foo"])
 
     def test_validator_applied_to_non_existent_arg_fails(self):
         self.commands.add("foo")(lambda context, arg: arg)
         with self.assertRaises(TypeError):
 
-            def func(context, wrong_arg):
+            def func(context: MpdContext, wrong_arg):
                 return wrong_arg
 
             self.commands.add("bar", arg=lambda v: v)(func)
@@ -228,7 +234,7 @@ class TestCommands(unittest.TestCase):
         return  # TODO: how to handle this
         with self.assertRaises(TypeError):
 
-            def func(context):
+            def func(context: MpdContext):
                 pass
 
             self.commands.add("bar", context=lambda v: v)(func)
@@ -237,19 +243,19 @@ class TestCommands(unittest.TestCase):
         def validdate(value):
             raise ValueError
 
-        def func(context, arg):
+        def func(context: MpdContext, arg):
             pass
 
         self.commands.add("bar", arg=validdate)(func)
 
         with self.assertRaises(exceptions.MpdArgError):
-            self.commands.call(["bar", "test"])
+            self.commands.call(context=None, tokens=["bar", "test"])
 
     def test_auth_required_gets_stored(self):
-        def func1(context):
+        def func1(context: MpdContext):
             pass
 
-        def func2(context):
+        def func2(context: MpdContext):
             pass
 
         self.commands.add("foo")(func1)
@@ -259,10 +265,10 @@ class TestCommands(unittest.TestCase):
         assert not self.commands.handlers["bar"].auth_required
 
     def test_list_command_gets_stored(self):
-        def func1(context):
+        def func1(context: MpdContext):
             pass
 
-        def func2(context):
+        def func2(context: MpdContext):
             pass
 
         self.commands.add("foo")(func1)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -5,6 +5,7 @@ import pytest
 from mopidy.backend import BackendProxy
 from mopidy.core import Core, CoreProxy
 from mopidy.models import Ref
+from mopidy_mpd import uri_mapper
 from mopidy_mpd.context import MpdContext
 
 from tests import dummy_backend
@@ -44,6 +45,7 @@ def mpd_context(backend_to_browse: BackendProxy) -> MpdContext:
     return MpdContext(
         config=None,
         core=core,
+        uri_map=uri_mapper.MpdUriMapper(core),
         dispatcher=None,
         session=None,
     )

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,90 @@
+from typing import cast
+
+import pykka
+import pytest
+from mopidy.backend import BackendProxy
+from mopidy.core import Core, CoreProxy
+from mopidy.models import Ref
+from mopidy_mpd.context import MpdContext
+
+from tests import dummy_backend
+
+
+@pytest.fixture()
+def a_track() -> Ref:
+    return Ref.track(uri="dummy:/a", name="a")
+
+
+@pytest.fixture()
+def b_track() -> Ref:
+    return Ref.track(uri="dummy:/foo/b", name="b")
+
+
+@pytest.fixture()
+def backend_to_browse(a_track: Ref, b_track: Ref) -> BackendProxy:
+    backend = cast(BackendProxy, dummy_backend.create_proxy())
+    backend.library.dummy_browse_result = {
+        "dummy:/": [
+            a_track,
+            Ref.directory(uri="dummy:/foo", name="foo"),
+        ],
+        "dummy:/foo": [
+            b_track,
+        ],
+    }
+    return backend
+
+
+@pytest.fixture()
+def mpd_context(backend_to_browse: BackendProxy) -> MpdContext:
+    core = cast(
+        CoreProxy,
+        Core.start(config=None, backends=[backend_to_browse]).proxy(),
+    )
+    return MpdContext(
+        config=None,
+        core=core,
+        dispatcher=None,
+        session=None,
+    )
+
+
+class TestMpdContext:
+    @classmethod
+    def teardown_class(cls):
+        pykka.ActorRegistry.stop_all()
+
+    def test_browse_root(self, mpd_context, a_track):
+        results = mpd_context.browse("dummy", recursive=False, lookup=False)
+
+        assert [("/dummy/a", a_track), ("/dummy/foo", None)] == list(results)
+
+    def test_browse_root_recursive(self, mpd_context, a_track, b_track):
+        results = mpd_context.browse("dummy", recursive=True, lookup=False)
+
+        assert [
+            ("/dummy", None),
+            ("/dummy/a", a_track),
+            ("/dummy/foo", None),
+            ("/dummy/foo/b", b_track),
+        ] == list(results)
+
+    @pytest.mark.parametrize(
+        "bad_ref",
+        [
+            Ref.track(uri="dummy:/x"),
+            Ref.track(name="x"),
+            Ref.directory(uri="dummy:/y"),
+            Ref.directory(name="y"),
+        ],
+    )
+    def test_browse_skips_bad_refs(
+        self, backend_to_browse, a_track, bad_ref, mpd_context
+    ):
+        backend_to_browse.library.dummy_browse_result = {
+            "dummy:/": [bad_ref, a_track],
+        }
+
+        results = mpd_context.browse("dummy", recursive=False, lookup=False)
+
+        assert [("/dummy/a", a_track)] == list(results)

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -8,7 +8,6 @@ from mopidy.core import Core, CoreProxy
 from mopidy.models import Ref
 from mopidy_mpd.dispatcher import MpdContext, MpdDispatcher
 from mopidy_mpd.exceptions import MpdAckError
-from mopidy_mpd.uri_mapper import MpdUriMapper
 
 from tests import dummy_backend
 
@@ -20,7 +19,11 @@ class MpdDispatcherTest(unittest.TestCase):
         self.core = cast(
             CoreProxy, Core.start(config=None, backends=[self.backend]).proxy()
         )
-        self.dispatcher = MpdDispatcher(config=config, core=self.core)
+        self.dispatcher = MpdDispatcher(
+            config=config,
+            core=self.core,
+            session=None,
+        )
 
     def tearDown(self):
         pykka.ActorRegistry.stop_all()
@@ -78,8 +81,10 @@ def mpd_context(backend_to_browse: BackendProxy) -> MpdContext:
         Core.start(config=None, backends=[backend_to_browse]).proxy(),
     )
     return MpdContext(
+        config=None,
         core=core,
-        uri_map=MpdUriMapper(core),
+        dispatcher=None,
+        session=None,
     )
 
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -3,6 +3,7 @@ from typing import cast
 
 import pykka
 from mopidy.core import Core, CoreProxy
+from mopidy_mpd import uri_mapper
 from mopidy_mpd.dispatcher import MpdDispatcher
 from mopidy_mpd.exceptions import MpdAckError
 
@@ -19,6 +20,7 @@ class MpdDispatcherTest(unittest.TestCase):
         self.dispatcher = MpdDispatcher(
             config=config,
             core=self.core,
+            uri_map=uri_mapper.MpdUriMapper(self.core),
             session=None,
         )
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -2,11 +2,8 @@ import unittest
 from typing import cast
 
 import pykka
-import pytest
-from mopidy.backend import BackendProxy
 from mopidy.core import Core, CoreProxy
-from mopidy.models import Ref
-from mopidy_mpd.dispatcher import MpdContext, MpdDispatcher
+from mopidy_mpd.dispatcher import MpdDispatcher
 from mopidy_mpd.exceptions import MpdAckError
 
 from tests import dummy_backend
@@ -47,83 +44,3 @@ class MpdDispatcherTest(unittest.TestCase):
             result[0]
             == 'ACK [0@0] {disabled} "disabled" has been disabled in the server'
         )
-
-
-@pytest.fixture()
-def a_track() -> Ref:
-    return Ref.track(uri="dummy:/a", name="a")
-
-
-@pytest.fixture()
-def b_track() -> Ref:
-    return Ref.track(uri="dummy:/foo/b", name="b")
-
-
-@pytest.fixture()
-def backend_to_browse(a_track: Ref, b_track: Ref) -> BackendProxy:
-    backend = cast(BackendProxy, dummy_backend.create_proxy())
-    backend.library.dummy_browse_result = {
-        "dummy:/": [
-            a_track,
-            Ref.directory(uri="dummy:/foo", name="foo"),
-        ],
-        "dummy:/foo": [
-            b_track,
-        ],
-    }
-    return backend
-
-
-@pytest.fixture()
-def mpd_context(backend_to_browse: BackendProxy) -> MpdContext:
-    core = cast(
-        CoreProxy,
-        Core.start(config=None, backends=[backend_to_browse]).proxy(),
-    )
-    return MpdContext(
-        config=None,
-        core=core,
-        dispatcher=None,
-        session=None,
-    )
-
-
-class TestMpdContext:
-    @classmethod
-    def teardown_class(cls):
-        pykka.ActorRegistry.stop_all()
-
-    def test_browse_root(self, mpd_context, a_track):
-        results = mpd_context.browse("dummy", recursive=False, lookup=False)
-
-        assert [("/dummy/a", a_track), ("/dummy/foo", None)] == list(results)
-
-    def test_browse_root_recursive(self, mpd_context, a_track, b_track):
-        results = mpd_context.browse("dummy", recursive=True, lookup=False)
-
-        assert [
-            ("/dummy", None),
-            ("/dummy/a", a_track),
-            ("/dummy/foo", None),
-            ("/dummy/foo/b", b_track),
-        ] == list(results)
-
-    @pytest.mark.parametrize(
-        "bad_ref",
-        [
-            Ref.track(uri="dummy:/x"),
-            Ref.track(name="x"),
-            Ref.directory(uri="dummy:/y"),
-            Ref.directory(name="y"),
-        ],
-    )
-    def test_browse_skips_bad_refs(
-        self, backend_to_browse, a_track, bad_ref, mpd_context
-    ):
-        backend_to_browse.library.dummy_browse_result = {
-            "dummy:/": [bad_ref, a_track],
-        }
-
-        results = mpd_context.browse("dummy", recursive=False, lookup=False)
-
-        assert [("/dummy/a", a_track)] == list(results)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -11,6 +11,7 @@ def test_on_start_logged(caplog):
     session.MpdSession(
         config=None,
         core=None,
+        uri_map=None,
         connection=connection,
     ).on_start()
 
@@ -23,6 +24,7 @@ def test_on_line_received_logged(caplog):
     mpd_session = session.MpdSession(
         config=None,
         core=None,
+        uri_map=None,
         connection=connection,
     )
     mpd_session.dispatcher = Mock(spec=dispatcher.MpdDispatcher)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -8,7 +8,11 @@ def test_on_start_logged(caplog):
     caplog.set_level(logging.INFO)
     connection = Mock(spec=network.Connection)
 
-    session.MpdSession(connection).on_start()
+    session.MpdSession(
+        config=None,
+        core=None,
+        connection=connection,
+    ).on_start()
 
     assert f"New MPD connection from {connection}" in caplog.text
 
@@ -16,7 +20,11 @@ def test_on_start_logged(caplog):
 def test_on_line_received_logged(caplog):
     caplog.set_level(logging.DEBUG)
     connection = Mock(spec=network.Connection)
-    mpd_session = session.MpdSession(connection)
+    mpd_session = session.MpdSession(
+        config=None,
+        core=None,
+        connection=connection,
+    )
     mpd_session.dispatcher = Mock(spec=dispatcher.MpdDispatcher)
     mpd_session.dispatcher.handle_request.return_value = [str(sentinel.resp)]
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -5,7 +5,7 @@ import pykka
 from mopidy import core
 from mopidy.core import PlaybackState
 from mopidy.models import Track
-from mopidy_mpd import dispatcher
+from mopidy_mpd import dispatcher, uri_mapper
 from mopidy_mpd.protocol import status
 
 from tests import dummy_audio, dummy_backend, dummy_mixer
@@ -42,6 +42,7 @@ class StatusHandlerTest(unittest.TestCase):
         self.dispatcher = dispatcher.MpdDispatcher(
             config=config,
             core=self.core,
+            uri_map=uri_mapper.MpdUriMapper(self.core),
             session=None,
         )
         self.context = self.dispatcher.context

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import cast
 
 import pykka
 from mopidy import core
@@ -19,20 +20,30 @@ STOPPED = PlaybackState.STOPPED
 
 class StatusHandlerTest(unittest.TestCase):
     def setUp(self):
-        config = {"core": {"max_tracklist_length": 10000}}
+        config = {
+            "core": {"max_tracklist_length": 10000},
+            "mpd": {"password": None},
+        }
 
         self.audio = dummy_audio.create_proxy()
         self.mixer = dummy_mixer.create_proxy()
         self.backend = dummy_backend.create_proxy(audio=self.audio)
 
-        self.core = core.Core.start(
-            config,
-            audio=self.audio,
-            mixer=self.mixer,
-            backends=[self.backend],
-        ).proxy()
+        self.core = cast(
+            core.CoreProxy,
+            core.Core.start(
+                config,
+                audio=self.audio,
+                mixer=self.mixer,
+                backends=[self.backend],
+            ).proxy(),
+        )
 
-        self.dispatcher = dispatcher.MpdDispatcher(core=self.core)
+        self.dispatcher = dispatcher.MpdDispatcher(
+            config=config,
+            core=self.core,
+            session=None,
+        )
         self.context = self.dispatcher.context
 
     def tearDown(self):

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -207,8 +207,20 @@ class PlaylistMpdFormatTest(unittest.TestCase):
                 Track(uri="baz", track_no=3),
             ]
         )
+
         result = translator.playlist_to_mpd_format(playlist, tagtype_list.TAGTYPE_LIST)
-        assert len(result) == 3
+
+        assert result == [
+            ("file", "foo"),
+            ("Time", 0),
+            ("Track", 1),
+            ("file", "bàr"),
+            ("Time", 0),
+            ("Track", 2),
+            ("file", "baz"),
+            ("Time", 0),
+            ("Track", 3),
+        ]
 
     def test_mpd_format_with_range(self):
         playlist = Playlist(
@@ -218,8 +230,9 @@ class PlaylistMpdFormatTest(unittest.TestCase):
                 Track(uri="baz", track_no=3),
             ]
         )
+
         result = translator.playlist_to_mpd_format(
             playlist, tagtype_list.TAGTYPE_LIST, start=1, end=2
         )
-        assert len(result) == 1
-        assert dict(result[0])["Track"] == 2
+
+        assert result == [("file", "bàr"), ("Time", 0), ("Track", 2)]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py311, py312, check-manifest, flake8
+envlist = py311, py312, typing, ruff-lint, ruff-format
 
 [testenv]
 sitepackages = true
@@ -10,6 +10,9 @@ commands =
         --cov=mopidy_mpd --cov-report=term-missing \
         {posargs}
 
+[testenv:pyright]
+deps = .[typing]
+commands = python -m pyright src
 
 [testenv:ruff-lint]
 deps = .[lint]


### PR DESCRIPTION
I don't really expect a full review of this, but feel free to look around and
maybe check the branch out and try browsing the code in an IDE with good type
support, like VS Code with the Pylance extension with "Inlay Hints" enabled.

- **Require Mopidy 4.0**
- **Make ruff enforce the presence of type hints**
- **Add type hints to everything**
- **Set up pyright in basic checking mode**
- **Fix pyright's basic warnings**
- **Move MpdContext out of dispatcher module**
- **Move util functions out of MpdDispatcher class**
- **Expose MpdUriMapper directly to protocol implementation**
- **Move subsystem events/subscriptions to MpdDispatcher**
- **Make MpdDispatcher use MpdSession directly**
- **Replace regexp pattern with full string matching**
- **Replace protocol_kwargs with something more type safe**
- **Properly type config object with MPD config**
- **Refactor command handler registration**
- **Work around too flexible typing of collections in models**
- **Work around lost type information**
- **Increase pyright's type checking mode to standard**
