### PR TITLE
update license expression to modern spdx license string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "mopidy-mpd"
 description = "Mopidy extension for controlling Mopidy from MPD clients"
 readme = "README.md"
 requires-python = ">= 3.13"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 authors = [{ name = "Stein Magnus Jodal", email = "stein.magnus@jodal.no" }]
 classifiers = [
     "Environment :: No Input/Output (Daemon)",


### PR DESCRIPTION
https://packaging.python.org/en/latest/specifications/license-expression/

Resolves warning when building with recent python versions.