### PR TITLE
fix: Handle dead actor when client disconnects

### DIFF
--- a/src/mopidy_mpd/network.py
+++ b/src/mopidy_mpd/network.py
@@ -396,7 +396,10 @@ class Connection:
 
         if not data:
             self.disable_recv()
-            self.actor_ref.tell({"close": True})
+            try:
+                self.actor_ref.tell({"close": True})
+            except pykka.ActorDeadError:
+                self.stop("Actor is dead.")
             return True
 
         try:

--- a/tests/network/test_connection.py
+++ b/tests/network/test_connection.py
@@ -445,6 +445,15 @@ class ConnectionTest(unittest.TestCase):
             call.actor_ref.tell({"close": True}),
         ]
 
+    def test_recv_callback_handles_dead_actors_on_close(self):
+        self.mock._sock = Mock(spec=socket.SocketType)
+        self.mock._sock.recv.return_value = b""
+        self.mock.actor_ref = Mock()
+        self.mock.actor_ref.tell.side_effect = pykka.ActorDeadError()
+
+        assert network.Connection.recv_callback(self.mock, sentinel.fd, GLib.IO_IN)
+        self.mock.stop.assert_called_once_with(any_unicode)
+
     def test_recv_callback_recoverable_error(self):
         self.mock._sock = Mock(spec=socket.SocketType)
 


### PR DESCRIPTION
Fixes #81.

`recv_callback` tells the session actor to close without guarding
`ActorDeadError`, while the identical `tell` four lines below **is** guarded:

```python
if not data:
    self.disable_recv()
    self.actor_ref.tell({"close": True})     # unguarded
    return True

try:
    self.actor_ref.tell({"received": data})  # same call, guarded
except pykka.ActorDeadError:
    self.stop("Actor is dead.")
```

If the actor is already dead when the peer hangs up — the normal race on a
disconnect — the exception is raised inside a GLib callback where nothing
catches it, and pykka logs the whole traceback.

Nothing is actually broken by it: the actor being gone is precisely the state
we were about to request. But anything that polls MPD and disconnects produces
one per poll. With Home Assistant's MPD integration pointed at Mopidy that was
28 tracebacks in a ten-minute window, which buries real errors in the log.

The change mirrors the existing guard on the `received` branch.

### Testing

Added `test_recv_callback_handles_dead_actors_on_close`, alongside the existing
`test_recv_callback_handles_dead_actors` it is modelled on. Confirmed it fails
on `main` with the reported `ActorDeadError` and passes with the fix; the rest
of the suite is unaffected (780 passed, 1 skipped).

Also running the patched version locally on Mopidy 4.0.1 — the tracebacks stop,
with no other change in behaviour.
